### PR TITLE
Fix interversion of next and prev translations in Spanish

### DIFF
--- a/i18n/es.yaml
+++ b/i18n/es.yaml
@@ -1,5 +1,5 @@
 - id: prev_page
-  translation: "Página siguiente"
+  translation: "Página anterior"
 
 - id: next_page
-  translation: "Página anterior"
+  translation: "Página siguiente"


### PR DESCRIPTION
Spanish translations for "next" and "previous" were swapped.