### PR TITLE
Implement copyright config option in site footer

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,5 +1,9 @@
 <footer class="footer">
+    {{- if .Site.Copyright }}
+    <span>{{ .Site.Copyright | markdownify }}</span>
+    {{- else }}
     <span>&copy; {{ now.Year }} <a href="{{ "" | absLangURL }}">{{ .Site.Title }}</a></span>
+    {{- end }}
     <span>&middot;</span>
     <span>Powered by <a href="https://gohugo.io/" rel="noopener noreferrer" target="_blank">Hugo️️</a>️</span>
     <span>&middot;</span>


### PR DESCRIPTION
This addresses #22 

If `.Site.Copyright` is defined, it is passed through `markdownify` and used in the footer.  
Otherwise, the previous default is used.