### PR TITLE
Add DateFormat theme parameter

### DIFF
--- a/layouts/_default/archives.html
+++ b/layouts/_default/archives.html
@@ -22,7 +22,7 @@
           {{- .Title | markdownify }}
         </h3>
         <div class="archive-meta">
-          <time>{{ .Date.Format "January 2, 2006" }}</time>
+          <time>{{ .Date.Format (default "January 2, 2006" .Site.Params.DateFormat) }}</time>
           {{- if $.Site.Params.ShowReadingTime }}&nbsp;·&nbsp;
           {{- $default_txt := print .ReadingTime " " "min" }}
           {{- i18n "read_time" .ReadingTime | default  $default_txt  }}{{ end }}

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -52,7 +52,7 @@
   </section>
   {{- end }}
   <footer class="entry-footer">
-    <time>{{ .Date.Format "January 2, 2006" }}</time>
+    <time>{{ .Date.Format (default "January 2, 2006" .Site.Params.DateFormat) }}</time>
     {{- if $.Site.Params.ShowReadingTime }}&nbsp;·&nbsp;
     {{- $default_txt := print .ReadingTime " " "min" }}
     {{- i18n "read_time" .ReadingTime | default  $default_txt  }}{{ end }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -8,7 +8,7 @@
     </h1>
     {{- if .Params.hideMeta }}{{ else }}
     <div class="post-meta">
-      <time>{{ .Date.Format "January 2, 2006" }}</time>
+      <time>{{ .Date.Format (default "January 2, 2006" .Site.Params.DateFormat) }}</time>
       {{- if $.Site.Params.ShowReadingTime -}}&nbsp;·&nbsp;
       {{- $default_txt := print .ReadingTime " " "min" }}
       {{- i18n "read_time" .ReadingTime | default  $default_txt  }}{{ end }}


### PR DESCRIPTION
Hi! Thanks for great theme!  

I think allowing user to set date format throughout the site and not be limited to "January 2, 2006"-format might come in handy, at least in my case.  I added handling of .Site.Params.DateFormat variable to the templates.   If parameter is not set it defaults to usual "January 2, 2006" so current users should not be affected.

Please let me know what you think.