### PR TITLE
Add full Russian localization

### DIFF
--- a/i18n/ru.yaml
+++ b/i18n/ru.yaml
@@ -1,5 +1,14 @@
 - id: prev_page
-  translation: "Сюда"
+  translation: 'Предыдущая'
 
 - id: next_page
-  translation: "Туда"
+  translation: 'Следующая'
+
+- id: read_time
+  translation: '{{ .Count }} мин'
+
+- id: toc
+  translation: 'Оглавление'
+
+- id: translations
+  translation: 'Переводы'


### PR DESCRIPTION
Hi!  I have added Russian localization for previously absent terms and changed prev_page/next_page from "Сюда"/"Туда" (which mean roughly "here" and "there") to "Предыдущая"/"Следующая" (literally "previous [page]" and "next [page]").