### PR TITLE
Responsive cover images

### DIFF
--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -14,3 +14,6 @@
 
 - id: translations
   translation: "Translations"
+
+- id: full_image
+  translation: "Original image"

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -14,6 +14,3 @@
 
 - id: translations
   translation: "Translations"
-
-- id: full_image
-  translation: "Original image"

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -31,15 +31,7 @@
 {{- $class = "post-entry tag-entry" }}
 {{- end }}
 <article class="{{ $class }}">
-  {{- if .Params.cover.image }}
-  <figure class="entry-cover">
-    {{- if (ne .Params.cover.relative true) }}
-    <img src="{{ .Params.cover.image | absURL }}" alt="{{ .Params.cover.alt | plainify }}">
-    {{- else}}
-    <img src="{{ (path.Join .RelPermalink .Params.cover.image ) | absURL }}" alt="{{ .Params.cover.alt | plainify }}">
-    {{- end}}
-  </figure>
-  {{- end }}
+  {{- partial "cover.html" (dict "cxt" . "caption" false) }}
   <header class="entry-header">
     <h2>
       {{ .Title }}

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -31,7 +31,7 @@
 {{- $class = "post-entry tag-entry" }}
 {{- end }}
 <article class="{{ $class }}">
-  {{- partial "cover.html" (dict "cxt" . "caption" false) }}
+  {{- partial "cover.html" (dict "cxt" . "IsHome" true) }}
   <header class="entry-header">
     <h2>
       {{ .Title }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -26,7 +26,7 @@
     </div>
     {{- end}}
   </header>
-  {{- partial "cover.html" (dict "cxt" . "caption" true) }}
+  {{- partial "cover.html" (dict "cxt" . "IsHome" false) }}
   {{- if .Params.ShowToc }}
   <div class="toc">
     <details {{if .Params.TocOpen }} open{{ end }}>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -26,16 +26,7 @@
     </div>
     {{- end}}
   </header>
-  {{- if .Params.cover.image }}
-  <figure class="entry-cover">
-    {{- if (ne .Params.cover.relative true) }}
-    <img src="{{ .Params.cover.image | absURL }}" alt="{{ .Params.cover.alt | plainify }}">
-    {{- else}}
-    <img src="{{ (path.Join .RelPermalink .Params.cover.image ) | absURL }}" alt="{{ .Params.cover.alt | plainify }}">
-    {{- end}}
-    <p>{{.Params.cover.caption | markdownify }}</p>
-  </figure>
-  {{- end }}
+  {{- partial "cover.html" (dict "cxt" . "caption" true) }}
   {{- if .Params.ShowToc }}
   <div class="toc">
     <details {{if .Params.TocOpen }} open{{ end }}>

--- a/layouts/partials/cover.html
+++ b/layouts/partials/cover.html
@@ -4,9 +4,10 @@
 {{- if .Params.cover.image }}
 
 {{- $sizes := (slice "360" "480" "720" "1080" "1500") }}
+{{- $processableFormats := (slice "jpg" "png" "tif" "bmp" "gif") }}
 
 {{- $file := (.Page.Resources.ByType "image").GetMatch (printf "*%s*" (.Params.cover.image)) }}
-{{- if not (isset $file "Width") }}{{ $file = false }}{{ end }} {{/* Exception for non-supported images */}}
+{{- with $file }} {{ if not (in $processableFormats .MediaType.SubType) }} {{ $file = false }} {{ end }}{{ end }}
 
 {{- $src := cond (default true .Site.Params.responsiveImages) $file false }}
 {{- $fallback := cond (default false .Params.cover.relative) (path.Join .RelPermalink .Params.cover.image) (.Params.cover.image) -}}

--- a/layouts/partials/cover.html
+++ b/layouts/partials/cover.html
@@ -16,15 +16,15 @@
 
 <figure class="entry-cover">  
 {{- if $responsiveImg -}}
-    {{- if $addLink }}<a href="{{ $src.RelPermalink | absURL }}" target="_blank" 
+    {{- if $addLink }}<a href="{{ $src.Permalink }}" target="_blank" 
         {{- with .Params.cover.caption }}title="{{ . | plainify }}"{{ else }}{{ with .Params.cover.alt }}title="{{ . | plainify }}"{{ end }}{{ end }}>
     {{- end }}
     <img sizes="(min-width: 768px) 720px, 100vw"
     srcset='{{- range $sizes -}}
-        {{ if ge $src.Width . }}{{ ($src.Resize (printf "%sx" .)).RelPermalink | absURL }} {{ (printf "%sw" .) }},{{ end }}
-    {{- end -}} {{$src.RelPermalink | absURL }} {{printf "%dw" ($src.Width)}}'
-    {{- if ge $src.Width "720" }}src="{{ ($src.Resize "720x").RelPermalink | absURL }}"
-    {{- else }}src="{{ $src.RelPermalink | absURL }}" {{ end }}{{ with .Params.cover.alt }} alt="{{ . | plainify }}"{{ end }}>
+        {{ if ge $src.Width . }}{{ ($src.Resize (printf "%sx" .)).Permalink }} {{ (printf "%sw" .) }},{{ end }}
+    {{- end -}} {{$src.Permalink }} {{printf "%dw" ($src.Width)}}'
+    {{- if ge $src.Width "720" }}src="{{ ($src.Resize "720x").Permalink }}"
+    {{- else }}src="{{ $src.Permalink }}" {{ end }}{{ with .Params.cover.alt }} alt="{{ . | plainify }}"{{ end }}>
     
 {{- else }}{{/* Fall back to full image */}}
     {{- if $addLink }}<a href="{{ $fallback | absURL }}" target="_blank" 

--- a/layouts/partials/cover.html
+++ b/layouts/partials/cover.html
@@ -3,7 +3,7 @@
 {{- with .cxt}} {{/* Apply proper context from dict */}}
 {{- if .Params.cover.image }}
 
-{{- $sizes := (slice "480" "720" "1080" "1500") }}
+{{- $sizes := (slice "360" "480" "720" "1080" "1500") }}
 
 {{- $src := cond (default true .Site.Params.responsiveImages) (.Page.Resources.GetMatch (printf "*%s*" (.Params.cover.image))) false }}
 {{- $fallback := cond (default false .Params.cover.relative) (path.Join .RelPermalink .Params.cover.image) (.Params.cover.image) -}}

--- a/layouts/partials/cover.html
+++ b/layouts/partials/cover.html
@@ -5,13 +5,14 @@
 
 {{- $sizes := (slice "480" "720" "1080" "1500") }}
 
-{{- $src := .Page.Resources.GetMatch (printf "*%s*" (.Params.cover.image)) }}
-{{- $fallback := cond .Params.cover.relative (path.Join .RelPermalink .Params.cover.image) (.Params.cover.image) -}}
+{{- $src := cond (default true .Site.Params.responsiveImages) (.Page.Resources.GetMatch (printf "*%s*" (.Params.cover.image))) false }}
+{{- $fallback := cond (default false .Params.cover.relative) (path.Join .RelPermalink .Params.cover.image) (.Params.cover.image) -}}
 
 {{- $addLink := and (not $IsHome) (default true .Site.Params.linkFullImages) -}}
+{{- $responsiveImg := and $src (default false .Params.cover.relative) -}}
 
 <figure class="entry-cover">  
-{{- if and $src .Params.cover.relative -}}
+{{- if $responsiveImg -}}
     {{- if $addLink }}<a href="{{ $src.RelPermalink }}" target="_blank" title="Original image">{{ end }}
     <img sizes="(min-width: 768px) 720px, 100vw"
     srcset='{{- range $sizes -}}

--- a/layouts/partials/cover.html
+++ b/layouts/partials/cover.html
@@ -5,7 +5,10 @@
 
 {{- $sizes := (slice "360" "480" "720" "1080" "1500") }}
 
-{{- $src := cond (default true .Site.Params.responsiveImages) (.Page.Resources.GetMatch (printf "*%s*" (.Params.cover.image))) false }}
+{{- $file := (.Page.Resources.ByType "image").GetMatch (printf "*%s*" (.Params.cover.image)) }}
+{{- if not (isset $file "Width") }}{{ $file = false }}{{ end }} {{/* Exception for non-supported images */}}
+
+{{- $src := cond (default true .Site.Params.responsiveImages) $file false }}
 {{- $fallback := cond (default false .Params.cover.relative) (path.Join .RelPermalink .Params.cover.image) (.Params.cover.image) -}}
 
 {{- $addLink := and (not $IsHome) (default true .Site.Params.linkFullImages) -}}

--- a/layouts/partials/cover.html
+++ b/layouts/partials/cover.html
@@ -13,7 +13,9 @@
 
 <figure class="entry-cover">  
 {{- if $responsiveImg -}}
-    {{- if $addLink }}<a href="{{ $src.RelPermalink | absURL }}" target="_blank" title="Original image">{{ end }}
+    {{- if $addLink }}<a href="{{ $src.RelPermalink | absURL }}" target="_blank" 
+        {{- with .Params.cover.caption }}title="{{ . | plainify }}"{{ else }}{{ with .Params.cover.alt }}title="{{ . | plainify }}"{{ end }}{{ end }}>
+    {{- end }}
     <img sizes="(min-width: 768px) 720px, 100vw"
     srcset='{{- range $sizes -}}
         {{ if ge $src.Width . }}{{ ($src.Resize (printf "%sx" .)).RelPermalink | absURL }} {{ (printf "%sw" .) }},{{ end }}
@@ -22,7 +24,9 @@
     {{- else }}src="{{ $src.RelPermalink | absURL }}" {{ end }}{{ with .Params.cover.alt }} alt="{{ . | plainify }}"{{ end }}>
     
 {{- else }}{{/* Fall back to full image */}}
-    {{- if $addLink }}<a href="{{ $fallback | absURL }}" target="_blank" title="Original image">{{ end }}
+    {{- if $addLink }}<a href="{{ $fallback | absURL }}" target="_blank" 
+        {{- with .Params.cover.caption }}title="{{ . | plainify }}"{{ else }}{{ with .Params.cover.alt }}title="{{ . | plainify }}"{{ end }}{{ end }}>
+    {{- end }}
     <img src="{{ $fallback | absURL }}" {{ with .Params.cover.alt }} alt="{{ . | plainify }}"{{ end }}>
 {{- end }}
 

--- a/layouts/partials/cover.html
+++ b/layouts/partials/cover.html
@@ -1,0 +1,17 @@
+{{ $caption := .caption }}
+
+{{with .cxt}} {{/* Apply proper context from dict */}}
+{{- if .Params.cover.image }}
+
+{{ $src := cond .Params.cover.relative (path.Join .RelPermalink .Params.cover.image) (.Params.cover.image) }}
+{{ $src = $src | absURL }}
+
+<figure class="entry-cover">  
+    <img src="{{ $src }}" {{ with .Params.cover.alt }} alt="{{ . | plainify }}"{{ end }}>
+{{- if $caption }}
+  <p>{{.Params.cover.caption | markdownify }}</p>
+{{- end }}
+</figure>
+
+{{- end }}{{/* End image */}}
+{{- end }}{{/* End context */}}

--- a/layouts/partials/cover.html
+++ b/layouts/partials/cover.html
@@ -18,7 +18,7 @@
         {{ if ge $src.Width . }}{{ ($src.Resize (printf "%sx" .)).RelPermalink }} {{ (printf "%sw" .) }},{{ end }}
     {{- end -}} {{$src.RelPermalink}} {{printf "%dw" ($src.Width)}}'
     {{- if ge $src.Width "720" }}src="{{ ($src.Resize "720x").RelPermalink }}"
-    {{- else }}src="{{ $src.RelPermalink }}" {{ with .Params.cover.alt }} alt="{{ . | plainify }}"{{ end }}{{ end }}>
+    {{- else }}src="{{ $src.RelPermalink }}" {{ end }}{{ with .Params.cover.alt }} alt="{{ . | plainify }}"{{ end }}>
     
 {{- else }}{{/* Fall back to full image */}}
     {{- if $addLink }}<a href="{{ $fallback | absURL }}" target="_blank" title="Original image">{{ end }}

--- a/layouts/partials/cover.html
+++ b/layouts/partials/cover.html
@@ -1,17 +1,30 @@
-{{ $caption := .caption }}
+{{- $IsHome := .IsHome }}
 
-{{with .cxt}} {{/* Apply proper context from dict */}}
+{{- with .cxt}} {{/* Apply proper context from dict */}}
 {{- if .Params.cover.image }}
 
-{{ $src := cond .Params.cover.relative (path.Join .RelPermalink .Params.cover.image) (.Params.cover.image) }}
-{{ $src = $src | absURL }}
+{{- $sizes := (slice "480" "720" "1080" "1500") }}
+
+{{- $src := .Page.Resources.GetMatch (printf "*%s*" (.Params.cover.image)) }}
+{{- $fallback := cond .Params.cover.relative (path.Join .RelPermalink .Params.cover.image) (.Params.cover.image) -}}
 
 <figure class="entry-cover">  
-    <img src="{{ $src }}" {{ with .Params.cover.alt }} alt="{{ . | plainify }}"{{ end }}>
-{{- if $caption }}
-  <p>{{.Params.cover.caption | markdownify }}</p>
+{{- if not $IsHome -}}<a href="{{ $fallback }}" target="_blank" title="Original image">{{- end -}}
+{{- if $src -}}
+    <img sizes="(min-width: 768px) 720px, 100vw"
+    srcset='{{- range $sizes -}}
+        {{ if ge $src.Width . }}{{ ($src.Resize (printf "%sx" .)).RelPermalink }} {{ (printf "%sw" .) }},{{ end }}
+    {{- end -}}'
+    {{- if ge $src.Width "720" }}src="{{ ($src.Resize "720x").RelPermalink }}"
+    {{- else }}src="{{ $src.RelPermalink }}" {{ with .Params.cover.alt }} alt="{{ . | plainify }}"{{ end }}{{ end }}>
+{{- else }}{{/* Fall back to full image */}}
+    <img src="{{ $fallback | absURL }}" {{ with .Params.cover.alt }} alt="{{ . | plainify }}"{{ end }}>
+{{- end }}
+
+{{- if not $IsHome }}
+  <p>{{.Params.cover.caption | markdownify }}</p></a>
 {{- end }}
 </figure>
 
 {{- end }}{{/* End image */}}
-{{- end }}{{/* End context */}}
+{{- end -}}{{/* End context */}}

--- a/layouts/partials/cover.html
+++ b/layouts/partials/cover.html
@@ -13,7 +13,7 @@
 
 <figure class="entry-cover">  
 {{- if $responsiveImg -}}
-    {{- if $addLink }}<a href="{{ $src.RelPermalink }}" target="_blank" title="Original image">{{ end }}
+    {{- if $addLink }}<a href="{{ $src.RelPermalink }}" target="_blank" title="{{- i18n "full_image" | default "Original image" }}">{{ end }}
     <img sizes="(min-width: 768px) 720px, 100vw"
     srcset='{{- range $sizes -}}
         {{ if ge $src.Width . }}{{ ($src.Resize (printf "%sx" .)).RelPermalink }} {{ (printf "%sw" .) }},{{ end }}
@@ -22,7 +22,7 @@
     {{- else }}src="{{ $src.RelPermalink }}" {{ end }}{{ with .Params.cover.alt }} alt="{{ . | plainify }}"{{ end }}>
     
 {{- else }}{{/* Fall back to full image */}}
-    {{- if $addLink }}<a href="{{ $fallback | absURL }}" target="_blank" title="Original image">{{ end }}
+    {{- if $addLink }}<a href="{{ $fallback | absURL }}" target="_blank" title="{{- i18n "full_image" | default "Original image" }}">{{ end }}
     <img src="{{ $fallback | absURL }}" {{ with .Params.cover.alt }} alt="{{ . | plainify }}"{{ end }}>
 {{- end }}
 

--- a/layouts/partials/cover.html
+++ b/layouts/partials/cover.html
@@ -1,37 +1,32 @@
 {{- with .cxt}} {{/* Apply proper context from dict */}}
 {{- if .Params.cover.image }}
+{{- $alt := (.Params.cover.alt | default .Params.cover.caption | plainify) }}
 <figure class="entry-cover">
     {{- $addLink := (and .Site.Params.cover.linkFullImages (not $.IsHome)) }}
-    {{- $fallback := cond (default false .Params.cover.relative) (path.Join .RelPermalink .Params.cover.image) (.Params.cover.image) -}}
-    {{- if $addLink }}<a href="{{ $fallback | absURL }}" target="_blank">{{ end -}}
-        {{- if .Params.cover.relative -}}{{/* i.e it is present in page bundle */}}
+    {{- $cover := (.Page.Resources.ByType "image").GetMatch (printf "*%s*" (.Params.cover.image)) }}
+    {{- if $cover -}}{{/* i.e it is present in page bundle */}}
+    {{- if $addLink }}<a href="{{ (path.Join .RelPermalink .Params.cover.image) | absURL }}" target="_blank">{{ end -}}
         {{- $sizes := (slice "360" "480" "720" "1080" "1500") }}
         {{- $processableFormats := (slice "jpg" "jpeg" "png" "tif" "bmp" "gif") }}
-        {{- $cover := (.Page.Resources.ByType "image").GetMatch (printf "*%s*" (.Params.cover.image)) }}
-
         {{- if (and (in $processableFormats $cover.MediaType.SubType) (ne .Site.Params.cover.responsiveImages false)) }}
         <img srcset="{{- range $size := $sizes -}}
                         {{- if (ge $cover.Width $size) -}}
                         {{ printf "%s %s" (($cover.Resize (printf "%sx q100" $size)).Permalink) (printf "%sw ," $size) -}}
                         {{ end }}
                     {{- end -}}{{$cover.Permalink }} {{printf "%dw" ($cover.Width)}}"
-            sizes="(min-width: 768px) 720px, 100vw" src="{{ $cover.Permalink }}"
-            alt="{{ .Params.cover.alt | default .Params.cover.caption | plainify }}" />
+            sizes="(min-width: 768px) 720px, 100vw" src="{{ $cover.Permalink }}" alt="{{ $alt }}" />
         {{- else }}{{/* page bundling disabled */}}
-        <img src="{{ (path.Join .RelPermalink .Params.cover.image ) | absURL }}"
-            alt="{{ .Params.cover.alt | plainify }}">
+        <img src="{{ (path.Join .RelPermalink .Params.cover.image) | absURL }}" alt="{{ $alt }}">
         {{- end }}
         {{- else }}{{/* For absolute urls and external links, no img processing here */}}
-        <img src="{{ .Params.cover.image | absURL }}"
-            alt="{{ .Params.cover.alt | default .Params.cover.caption | plainify }}">
-        {{- end }}
-        {{- if $addLink }}</a>{{ end -}}
-    {{/*  Display Caption  */}}
-    {{- if not $.IsHome }}
-    {{- with .Params.cover.caption }}
-    <p>{{ . | markdownify }}</p>
-    {{- end }}
-    {{- end }}
+        {{- if $addLink }}<a href="{{ (.Params.cover.image) | absURL }}" target="_blank">{{ end -}}
+            <img src="{{ (.Params.cover.image) | absURL }}" alt="{{ $alt }}">
+            {{- end }}
+            {{- if $addLink }}</a>{{ end -}}
+        {{/*  Display Caption  */}}
+        {{- if not $.IsHome }}{{- with .Params.cover.caption }}
+        <p>{{ . | markdownify }}</p>
+        {{- end }}{{- end }}
 </figure>
 {{- end }}{{/* End image */}}
 {{- end -}}{{/* End context */}}

--- a/layouts/partials/cover.html
+++ b/layouts/partials/cover.html
@@ -5,7 +5,7 @@
     {{- $addLink := (and .Site.Params.cover.linkFullImages (not $.IsHome)) }}
     {{- $cover := (.Page.Resources.ByType "image").GetMatch (printf "*%s*" (.Params.cover.image)) }}
     {{- if $cover -}}{{/* i.e it is present in page bundle */}}
-    {{- if $addLink }}<a href="{{ (path.Join .RelPermalink .Params.cover.image) | absURL }}" target="_blank">{{ end -}}
+        {{- if $addLink }}<a href="{{ (path.Join .RelPermalink .Params.cover.image) | absURL }}" target="_blank">{{ end -}}
         {{- $sizes := (slice "360" "480" "720" "1080" "1500") }}
         {{- $processableFormats := (slice "jpg" "jpeg" "png" "tif" "bmp" "gif") }}
         {{- if (and (in $processableFormats $cover.MediaType.SubType) (ne .Site.Params.cover.responsiveImages false)) }}
@@ -15,18 +15,18 @@
                         {{ end }}
                     {{- end -}}{{$cover.Permalink }} {{printf "%dw" ($cover.Width)}}"
             sizes="(min-width: 768px) 720px, 100vw" src="{{ $cover.Permalink }}" alt="{{ $alt }}" />
-        {{- else }}{{/* page bundling disabled */}}
+        {{- else }}{{/* Unprocessable image or responsive images disabled */}}
         <img src="{{ (path.Join .RelPermalink .Params.cover.image) | absURL }}" alt="{{ $alt }}">
         {{- end }}
-        {{- else }}{{/* For absolute urls and external links, no img processing here */}}
+    {{- else }}{{/* For absolute urls and external links, no img processing here */}}
         {{- if $addLink }}<a href="{{ (.Params.cover.image) | absURL }}" target="_blank">{{ end -}}
             <img src="{{ (.Params.cover.image) | absURL }}" alt="{{ $alt }}">
-            {{- end }}
-            {{- if $addLink }}</a>{{ end -}}
-        {{/*  Display Caption  */}}
-        {{- if not $.IsHome }}{{- with .Params.cover.caption }}
-        <p>{{ . | markdownify }}</p>
-        {{- end }}{{- end }}
+    {{- end }}
+    {{- if $addLink }}</a>{{ end -}}
+    {{/*  Display Caption  */}}
+    {{- if not $.IsHome }}
+        {{ with .Params.cover.caption }}<p>{{ . | markdownify }}</p>{{- end }}
+    {{- end }}
 </figure>
 {{- end }}{{/* End image */}}
 {{- end -}}{{/* End context */}}

--- a/layouts/partials/cover.html
+++ b/layouts/partials/cover.html
@@ -8,21 +8,25 @@
 {{- $src := .Page.Resources.GetMatch (printf "*%s*" (.Params.cover.image)) }}
 {{- $fallback := cond .Params.cover.relative (path.Join .RelPermalink .Params.cover.image) (.Params.cover.image) -}}
 
+{{- $addLink := and (not $IsHome) (default true .Site.Params.linkFullImages) -}}
+
 <figure class="entry-cover">  
-{{- if not $IsHome -}}<a href="{{ $fallback }}" target="_blank" title="Original image">{{- end -}}
-{{- if $src -}}
+{{- if and $src .Params.cover.relative -}}
+    {{- if $addLink }}<a href="{{ $src.RelPermalink }}" target="_blank" title="Original image">{{ end }}
     <img sizes="(min-width: 768px) 720px, 100vw"
     srcset='{{- range $sizes -}}
         {{ if ge $src.Width . }}{{ ($src.Resize (printf "%sx" .)).RelPermalink }} {{ (printf "%sw" .) }},{{ end }}
     {{- end -}} {{$src.RelPermalink}} {{printf "%dw" ($src.Width)}}'
     {{- if ge $src.Width "720" }}src="{{ ($src.Resize "720x").RelPermalink }}"
     {{- else }}src="{{ $src.RelPermalink }}" {{ with .Params.cover.alt }} alt="{{ . | plainify }}"{{ end }}{{ end }}>
+    
 {{- else }}{{/* Fall back to full image */}}
+    {{- if $addLink }}<a href="{{ $fallback | absURL }}" target="_blank" title="Original image">{{ end }}
     <img src="{{ $fallback | absURL }}" {{ with .Params.cover.alt }} alt="{{ . | plainify }}"{{ end }}>
 {{- end }}
 
-{{- if not $IsHome }}
-  <p>{{.Params.cover.caption | markdownify }}</p></a>
+{{- if not $IsHome -}} {{- if $addLink }}</a>{{ end -}}
+  <p>{{.Params.cover.caption | markdownify }}</p>
 {{- end }}
 </figure>
 

--- a/layouts/partials/cover.html
+++ b/layouts/partials/cover.html
@@ -1,43 +1,37 @@
-{{- $IsHome := .IsHome }}
-
 {{- with .cxt}} {{/* Apply proper context from dict */}}
 {{- if .Params.cover.image }}
+<figure class="entry-cover">
+    {{- $addLink := (and .Site.Params.cover.linkFullImages (not $.IsHome)) }}
+    {{- $fallback := cond (default false .Params.cover.relative) (path.Join .RelPermalink .Params.cover.image) (.Params.cover.image) -}}
+    {{- if $addLink }}<a href="{{ $fallback | absURL }}" target="_blank">{{ end -}}
+        {{- if .Params.cover.relative -}}{{/* i.e it is present in page bundle */}}
+        {{- $sizes := (slice "360" "480" "720" "1080" "1500") }}
+        {{- $processableFormats := (slice "jpg" "jpeg" "png" "tif" "bmp" "gif") }}
+        {{- $cover := (.Page.Resources.ByType "image").GetMatch (printf "*%s*" (.Params.cover.image)) }}
 
-{{- $sizes := (slice "360" "480" "720" "1080" "1500") }}
-{{- $processableFormats := (slice "jpg" "png" "tif" "bmp" "gif") }}
-
-{{- $file := (.Page.Resources.ByType "image").GetMatch (printf "*%s*" (.Params.cover.image)) }}
-{{- with $file }} {{ if not (in $processableFormats .MediaType.SubType) }} {{ $file = false }} {{ end }}{{ end }}
-
-{{- $src := cond (default true .Site.Params.responsiveImages) $file false }}
-{{- $fallback := cond (default false .Params.cover.relative) (path.Join .RelPermalink .Params.cover.image) (.Params.cover.image) -}}
-
-{{- $addLink := and (not $IsHome) (default true .Site.Params.linkFullImages) -}}
-{{- $responsiveImg := and $src (default false .Params.cover.relative) -}}
-
-<figure class="entry-cover">  
-{{- if $responsiveImg -}}
-    {{- if $addLink }}<a href="{{ $src.Permalink }}" target="_blank" 
-        {{- with .Params.cover.caption }}title="{{ . | plainify }}"{{ else }}{{ with .Params.cover.alt }}title="{{ . | plainify }}"{{ end }}{{ end }}>
+        {{- if (and (in $processableFormats $cover.MediaType.SubType) (ne .Site.Params.cover.responsiveImages false)) }}
+        <img srcset="{{- range $size := $sizes -}}
+                        {{- if (ge $cover.Width $size) -}}
+                        {{ printf "%s %s" (($cover.Resize (printf "%sx q100" $size)).Permalink) (printf "%sw ," $size) -}}
+                        {{ end }}
+                    {{- end -}}{{$cover.Permalink }} {{printf "%dw" ($cover.Width)}}"
+            sizes="(min-width: 768px) 720px, 100vw" src="{{ $cover.Permalink }}"
+            alt="{{ .Params.cover.alt | default .Params.cover.caption | plainify }}" />
+        {{- else }}{{/* page bundling disabled */}}
+        <img src="{{ (path.Join .RelPermalink .Params.cover.image ) | absURL }}"
+            alt="{{ .Params.cover.alt | plainify }}">
+        {{- end }}
+        {{- else }}{{/* For absolute urls and external links, no img processing here */}}
+        <img src="{{ .Params.cover.image | absURL }}"
+            alt="{{ .Params.cover.alt | default .Params.cover.caption | plainify }}">
+        {{- end }}
+        {{- if $addLink }}</a>{{ end -}}
+    {{/*  Display Caption  */}}
+    {{- if not $.IsHome }}
+    {{- with .Params.cover.caption }}
+    <p>{{ . | markdownify }}</p>
     {{- end }}
-    <img sizes="(min-width: 768px) 720px, 100vw"
-    srcset='{{- range $sizes -}}
-        {{ if ge $src.Width . }}{{ ($src.Resize (printf "%sx" .)).Permalink }} {{ (printf "%sw" .) }},{{ end }}
-    {{- end -}} {{$src.Permalink }} {{printf "%dw" ($src.Width)}}'
-    {{- if ge $src.Width "720" }}src="{{ ($src.Resize "720x").Permalink }}"
-    {{- else }}src="{{ $src.Permalink }}" {{ end }}{{ with .Params.cover.alt }} alt="{{ . | plainify }}"{{ end }}>
-    
-{{- else }}{{/* Fall back to full image */}}
-    {{- if $addLink }}<a href="{{ $fallback | absURL }}" target="_blank" 
-        {{- with .Params.cover.caption }}title="{{ . | plainify }}"{{ else }}{{ with .Params.cover.alt }}title="{{ . | plainify }}"{{ end }}{{ end }}>
     {{- end }}
-    <img src="{{ $fallback | absURL }}" {{ with .Params.cover.alt }} alt="{{ . | plainify }}"{{ end }}>
-{{- end }}
-
-{{- if not $IsHome -}} {{- if $addLink }}</a>{{ end -}}
-  <p>{{.Params.cover.caption | markdownify }}</p>
-{{- end }}
 </figure>
-
 {{- end }}{{/* End image */}}
 {{- end -}}{{/* End context */}}

--- a/layouts/partials/cover.html
+++ b/layouts/partials/cover.html
@@ -14,7 +14,7 @@
     <img sizes="(min-width: 768px) 720px, 100vw"
     srcset='{{- range $sizes -}}
         {{ if ge $src.Width . }}{{ ($src.Resize (printf "%sx" .)).RelPermalink }} {{ (printf "%sw" .) }},{{ end }}
-    {{- end -}}'
+    {{- end -}} {{$src.RelPermalink}} {{printf "%dw" ($src.Width)}}'
     {{- if ge $src.Width "720" }}src="{{ ($src.Resize "720x").RelPermalink }}"
     {{- else }}src="{{ $src.RelPermalink }}" {{ with .Params.cover.alt }} alt="{{ . | plainify }}"{{ end }}{{ end }}>
 {{- else }}{{/* Fall back to full image */}}

--- a/layouts/partials/cover.html
+++ b/layouts/partials/cover.html
@@ -13,13 +13,13 @@
 
 <figure class="entry-cover">  
 {{- if $responsiveImg -}}
-    {{- if $addLink }}<a href="{{ $src.RelPermalink }}" target="_blank" title="{{- i18n "full_image" | default "Original image" }}">{{ end }}
+    {{- if $addLink }}<a href="{{ $src.RelPermalink | absURL }}" target="_blank" title="{{- i18n "full_image" | default "Original image" }}">{{ end }}
     <img sizes="(min-width: 768px) 720px, 100vw"
     srcset='{{- range $sizes -}}
-        {{ if ge $src.Width . }}{{ ($src.Resize (printf "%sx" .)).RelPermalink }} {{ (printf "%sw" .) }},{{ end }}
-    {{- end -}} {{$src.RelPermalink}} {{printf "%dw" ($src.Width)}}'
-    {{- if ge $src.Width "720" }}src="{{ ($src.Resize "720x").RelPermalink }}"
-    {{- else }}src="{{ $src.RelPermalink }}" {{ end }}{{ with .Params.cover.alt }} alt="{{ . | plainify }}"{{ end }}>
+        {{ if ge $src.Width . }}{{ ($src.Resize (printf "%sx" .)).RelPermalink | absURL }} {{ (printf "%sw" .) }},{{ end }}
+    {{- end -}} {{$src.RelPermalink | absURL }} {{printf "%dw" ($src.Width)}}'
+    {{- if ge $src.Width "720" }}src="{{ ($src.Resize "720x").RelPermalink | absURL }}"
+    {{- else }}src="{{ $src.RelPermalink | absURL }}" {{ end }}{{ with .Params.cover.alt }} alt="{{ . | plainify }}"{{ end }}>
     
 {{- else }}{{/* Fall back to full image */}}
     {{- if $addLink }}<a href="{{ $fallback | absURL }}" target="_blank" title="{{- i18n "full_image" | default "Original image" }}">{{ end }}

--- a/layouts/partials/cover.html
+++ b/layouts/partials/cover.html
@@ -13,7 +13,7 @@
 
 <figure class="entry-cover">  
 {{- if $responsiveImg -}}
-    {{- if $addLink }}<a href="{{ $src.RelPermalink | absURL }}" target="_blank" title="{{- i18n "full_image" | default "Original image" }}">{{ end }}
+    {{- if $addLink }}<a href="{{ $src.RelPermalink | absURL }}" target="_blank" title="Original image">{{ end }}
     <img sizes="(min-width: 768px) 720px, 100vw"
     srcset='{{- range $sizes -}}
         {{ if ge $src.Width . }}{{ ($src.Resize (printf "%sx" .)).RelPermalink | absURL }} {{ (printf "%sw" .) }},{{ end }}
@@ -22,7 +22,7 @@
     {{- else }}src="{{ $src.RelPermalink | absURL }}" {{ end }}{{ with .Params.cover.alt }} alt="{{ . | plainify }}"{{ end }}>
     
 {{- else }}{{/* Fall back to full image */}}
-    {{- if $addLink }}<a href="{{ $fallback | absURL }}" target="_blank" title="{{- i18n "full_image" | default "Original image" }}">{{ end }}
+    {{- if $addLink }}<a href="{{ $fallback | absURL }}" target="_blank" title="Original image">{{ end }}
     <img src="{{ $fallback | absURL }}" {{ with .Params.cover.alt }} alt="{{ . | plainify }}"{{ end }}>
 {{- end }}
 


### PR DESCRIPTION
I am working on adding responsive sizing for cover images (using _srcset_ to provide multiple sizes of the cover image, similar to [this](https://laurakalbag.com/processing-responsive-images-with-hugo/)).

The first step is to move the cover image to a new partial, as this was shared between the homepage and single posts.