### PR TITLE
chore: add go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module adityatelange/hugo-PaperMod
+module github.com/adityatelange/hugo-PaperMod
 
 go 1.12

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module adityatelange/hugo-PaperMod
+
+go 1.12


### PR DESCRIPTION
This will allow https://gohugo.io/hugo-modules/use-modules/#use-a-module-for-a-theme without the `incompatible` tag.

So a user can simply write:
```toml
# config.toml
theme = "github.com/theNewDynamic/gohugo-theme-ananke"
```