### PR TITLE
header: disable user-select for theme-toggle

### DIFF
--- a/assets/css/header.css
+++ b/assets/css/header.css
@@ -34,9 +34,10 @@
     margin-inline-end: 8px;
 }
 
-.theme-toggle svg{
+.theme-toggle svg {
     height: 18px;
     margin: 0 10px;
+    user-select: none;
 }
 
 body.dark #moon{


### PR DESCRIPTION
Now, clicking twice on theme switch may select other text on the header bar. This PR fix this issue.