### PR TITLE
Fix broken footnote anchor link scrolling

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -30,8 +30,8 @@
     document.querySelectorAll('a[href^="#"]').forEach(anchor => {
         anchor.addEventListener("click", function (e) {
             e.preventDefault();
-
-            document.querySelector(this.getAttribute("href")).scrollIntoView({
+            var id = this.getAttribute("href").substr(1);
+            document.querySelector(`[id='${id}']`).scrollIntoView({
                 behavior: "smooth"
             });
         });


### PR DESCRIPTION
Footnotes result in anchor link hrefs such as `#fn:1`. However, it appears that colons are special characters that break the `document.querySelector` function. When footnotes were clicked, this error was produced: "Failed to execute 'querySelector' on 'Document': '#fn:1' is not a valid selector". The solution implemented is based on [this stackoverflow](https://stackoverflow.com/a/51396346/300212) answer.

Let me know if there's anything you'd like me to change. Thanks in advance!