### PR TITLE
Fix typo "expored"->"expired"

### DIFF
--- a/content/posts/papermod/papermod-installation.md
+++ b/content/posts/papermod/papermod-installation.md
@@ -65,7 +65,7 @@ theme: hugo-PaperMod
 enableRobotsTXT: true
 buildDrafts: false
 buildFuture: false
-buildExpored: false
+buildExpired: false
 
 googleAnalytics: UA-123-45
 


### PR DESCRIPTION
Just a little typo fix I noticed while going over the Installation page :)