### PR TITLE
Broken description due to extra quote

### DIFF
--- a/content/posts/papermod/papermod-installation.md
+++ b/content/posts/papermod/papermod-installation.md
@@ -76,7 +76,7 @@ minify:
 params:
   env: production # to enable google analytics, opengraph, twitter-cards and schema.
   title: ExampleSite
-  description: 'ExampleSite's description'
+  description: 'ExampleSite description'
   author: Me
   # author: ["Me", "You"] # multiple authors
 


### PR DESCRIPTION
Hugo fails to build the website with the config in the Installation post as it has an extra quote in the "description".
I think that "ExampleSite description" is a nice compromise