### PR TITLE
Enable theme toggle unless specifically disabled

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -63,7 +63,7 @@
     })
 </script>
 {{- else -}}
-<!-- case where owner disables theme button after deployment, this resets the stored theme -->
+{{/*  case where owner disables theme button after deployment, this resets the stored theme  */}}
 <script>
     localStorage.removeItem("pref-theme");
 </script>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -50,7 +50,7 @@
         localStorage.setItem("menu-scroll-position", document.getElementById('menu').scrollLeft);
     }
 </script>
-{{- if (and (not .Site.Params.disableThemeToggle) (not (or (eq .Site.Params.defaultTheme "light") (eq .Site.Params.defaultTheme "dark")))) }}
+{{- if (not .Site.Params.disableThemeToggle) }}
 <script>
     document.getElementById("theme-toggle").addEventListener("click", () => {
         if (document.body.className.includes("dark")) {

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,15 +1,11 @@
-{{- if (and (not .Site.Params.disableThemeToggle) (not (or (eq .Site.Params.defaultTheme "light") (eq .Site.Params.defaultTheme "dark")))) }}
+{{- if (not .Site.Params.disableThemeToggle) }}
 <script>
     // load memory
     if (localStorage.getItem("pref-theme") === "dark") {
         document.body.classList.add('dark');
     } else if (localStorage.getItem("pref-theme") === "light") {
         document.body.classList.remove('dark')
-    } else {
-        if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
-            document.body.classList.add('dark');
-        }
-    }
+    } 
 
 </script>
 {{- end }}
@@ -41,7 +37,7 @@
                 {{- .Site.Params.label.text | default .Site.Title -}}
             </a>
             <span class="logo-switches">
-                {{- if (and (not .Site.Params.disableThemeToggle) (not (or (eq .Site.Params.defaultTheme "light") (eq .Site.Params.defaultTheme "dark")))) }}
+                {{- if (not .Site.Params.disableThemeToggle) }}
                 <span class="theme-toggle">
                     <a id="theme-toggle" accesskey="t">
                         <svg id="moon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,17 +1,32 @@
-{{- if (not .Site.Params.disableThemeToggle) }}
+{{- if (eq .Site.Params.defaultTheme "light") }}
 <script>
-    // load memory
     if (localStorage.getItem("pref-theme") === "dark") {
         document.body.classList.add('dark');
     } else if (localStorage.getItem("pref-theme") === "light") {
         document.body.classList.remove('dark')
-    } 
+    } else {
+        document.body.classList.remove('dark')
+    }
 
 </script>
-{{- end }}
-{{- if (and (.Site.Params.disableThemeToggle) (eq .Site.Params.defaultTheme "auto")) }}
+{{- else if (eq .Site.Params.defaultTheme "dark") }}
 <script>
-    if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+    if (localStorage.getItem("pref-theme") === "dark") {
+        document.body.classList.add('dark');
+    } else if (localStorage.getItem("pref-theme") === "light") {
+        document.body.classList.remove('dark')
+    } else {
+        document.body.classList.add('dark');
+    }
+
+</script>
+{{- else if (or (eq .Site.Params.defaultTheme "auto") (not .Site.Params.disableThemeToggle) ) }}
+<script>
+    if (localStorage.getItem("pref-theme") === "dark") {
+        document.body.classList.add('dark');
+    } else if (localStorage.getItem("pref-theme") === "light") {
+        document.body.classList.remove('dark')
+    } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
         document.body.classList.add('dark');
     }
 


### PR DESCRIPTION
Users can specify one of these three theme modes: Auto, Dark, Light.
In addition, there is a configuration option named `disableThemeToggle` that when disabled (i.e Theme toggle is enabled) allows the user to specify what theme they prefer to use, regardless of their system theme.

Currently, even when this config is disabeld (means that the Theme Toggle should be visible), the toggle would not be visible unless the author of the blog specified they want t use the "Auto" theme. That means, that if I, as a website owner, want the default theme to be `Light` and also allow the visitors to toggle the theme, I can't do this.


This Pull Request fixes this and honor `disableThemeToggle` regardles of the selected theme in the configuration. This mean, that the website owner have more control over whether the toggle will be shown or not.


