### PR TITLE
Improve theme switch logic

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -65,10 +65,4 @@
     })
 
 </script>
-{{- else -}}
-{{/*  case where owner disables theme button after deployment, this resets the stored theme  */}}
-<script>
-    localStorage.removeItem("pref-theme");
-
-</script>
 {{- end }}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,4 +1,6 @@
+{{- /*  theme-toggle is enabled  */}}
 {{- if (not .Site.Params.disableThemeToggle) }}
+{{- /*  theme is light  */}}
 {{- if (eq .Site.Params.defaultTheme "light") }}
 <script>
     if (localStorage.getItem("pref-theme") === "dark") {
@@ -6,6 +8,7 @@
     }
 
 </script>
+{{- /*  theme is dark  */}}
 {{- else if (eq .Site.Params.defaultTheme "dark") }}
 <script>
     if (localStorage.getItem("pref-theme") === "light") {
@@ -14,6 +17,7 @@
 
 </script>
 {{- else }}
+{{- /*  theme is auto  */}}
 <script>
     if (localStorage.getItem("pref-theme") === "dark") {
         document.body.classList.add('dark');
@@ -25,6 +29,7 @@
 
 </script>
 {{- end }}
+{{- /*  theme-toggle is enabled and theme is auto  */}}
 {{- else if (and (ne .Site.Params.defaultTheme "light") (ne .Site.Params.defaultTheme "dark"))}}
 <script>
     if (window.matchMedia('(prefers-color-scheme: dark)').matches) {

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,32 +1,33 @@
+{{- if (not .Site.Params.disableThemeToggle) }}
 {{- if (eq .Site.Params.defaultTheme "light") }}
 <script>
     if (localStorage.getItem("pref-theme") === "dark") {
         document.body.classList.add('dark');
-    } else if (localStorage.getItem("pref-theme") === "light") {
-        document.body.classList.remove('dark')
-    } else {
-        document.body.classList.remove('dark')
     }
 
 </script>
 {{- else if (eq .Site.Params.defaultTheme "dark") }}
 <script>
-    if (localStorage.getItem("pref-theme") === "dark") {
-        document.body.classList.add('dark');
-    } else if (localStorage.getItem("pref-theme") === "light") {
+    if (localStorage.getItem("pref-theme") === "light") {
         document.body.classList.remove('dark')
-    } else {
-        document.body.classList.add('dark');
     }
 
 </script>
-{{- else if (or (eq .Site.Params.defaultTheme "auto") (not .Site.Params.disableThemeToggle) ) }}
+{{- else }}
 <script>
     if (localStorage.getItem("pref-theme") === "dark") {
         document.body.classList.add('dark');
     } else if (localStorage.getItem("pref-theme") === "light") {
         document.body.classList.remove('dark')
     } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+        document.body.classList.add('dark');
+    }
+
+</script>
+{{- end }}
+{{- else if (and (ne .Site.Params.defaultTheme "light") (ne .Site.Params.defaultTheme "dark"))}}
+<script>
+    if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
         document.body.classList.add('dark');
     }
 

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -29,7 +29,7 @@
 
 </script>
 {{- end }}
-{{- /*  theme-toggle is enabled and theme is auto  */}}
+{{- /*  theme-toggle is disabled and theme is auto  */}}
 {{- else if (and (ne .Site.Params.defaultTheme "light") (ne .Site.Params.defaultTheme "dark"))}}
 <script>
     if (window.matchMedia('(prefers-color-scheme: dark)').matches) {


### PR DESCRIPTION
- removes unnecessary local-storage item removal
- less inline script on build
- assumes `defaultTheme` as `auto` when value is not `dark` or `light`

should work according to table at [docs](https://adityatelange.github.io/hugo-PaperMod/posts/papermod/papermod-features/#theme-switch-toggle-enabled-by-default)