### PR TITLE
Obey baseURL when fetching index.json

### DIFF
--- a/assets/js/fastsearch.js
+++ b/assets/js/fastsearch.js
@@ -40,7 +40,7 @@ function fetchJSONFile(path, callback) {
 
 // load our search index, only executed once
 function loadSearch() {
-    fetchJSONFile('{{ "index.json" | relURL }}', function (data) {
+    fetchJSONFile('{{ "index.json" | relLangURL }}', function (data) {
 
         // fuse.js options; check fuse.js website for details
         var options = {

--- a/assets/js/fastsearch.js
+++ b/assets/js/fastsearch.js
@@ -47,7 +47,7 @@ function fetchJSONFile(path, callback) {
 
 // load our search index, only executed once
 function loadSearch() {
-    fetchJSONFile('/index.json', function (data) {
+    fetchJSONFile('{{ "index.json" | relURL }}', function (data) {
 
         var options = { // fuse.js options; check fuse.js website for details
             shouldSort: true,

--- a/layouts/_default/search.html
+++ b/layouts/_default/search.html
@@ -43,7 +43,7 @@
     }
 
 </style>
-{{$fastsearch := slice (resources.Get "js/fastsearch.js") | resources.Concat "assets/js/fastsearch.js" | minify}}
+{{$fastsearch := slice (resources.Get "js/fastsearch.js") | resources.Concat "assets/js/fastsearch.js" | resources.ExecuteAsTemplate "assets/js/fastsearch.js" . | minify}}
 <script defer src="{{ $fastsearch.Permalink }}" onload="loadSearch();"></script>
 <script src="https://cdn.jsdelivr.net/npm/fuse.js/dist/fuse.js"></script>
 

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -31,7 +31,7 @@
 {{- end}}
 <!-- Search -->
 {{- if (eq .Layout `search`) -}}
-{{- $fastsearch := resources.Get "js/fastsearch.js" }}
+{{- $fastsearch := resources.Get "js/fastsearch.js" | resources.ExecuteAsTemplate "assets/js/fastsearch.js" . }}
 {{- $fusejs := resources.Get "js/fuse.js" }}
 {{- if not .Site.Params.assets.disableFingerprinting }}
 {{- $search := (slice $fusejs $fastsearch ) | resources.Concat "assets/js/search.js" | minify | fingerprint }}


### PR DESCRIPTION
This fixes the problem I mentioned [here](https://github.com/adityatelange/hugo-PaperMod/pull/105#discussion_r535585084), where `fastsearch.js` always tries to fetch `/index.json`