### PR TITLE
fix custom taxonomy urls

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -45,15 +45,14 @@
     {{- partial "anchored_headings.html" .Content -}}
   </div>
   <footer class="post-footer">
-    {{- with .Params.tags -}}
-      <ul class="post-tags">
-        {{- range $index, $value := . -}}
-        {{- $url := . | urlize | urls.Parse -}}
-        {{- $tag := $url.Path | printf "/tags/%v" | $.Site.GetPage -}}
-        <li><a href="{{ $tag.RelPermalink }}">{{ $tag.Title }}</a></li>
-        {{- end -}}
-      </ul>
-    {{- end -}}
+    {{- with .Params.tags }}
+    <ul class="post-tags">
+      {{- range . }}
+      {{- $href := $.Site.GetPage (print "tags/" .)  }}
+      <li><a href="{{ $href.Permalink }}">{{ . }}</a></li>
+      {{- end }}
+    </ul>
+    {{- end }}
     {{- if (and .Site.Params.ShowShareButtons (ne .Params.disableShare true) ) }}
     {{- partial "share_icons.html" . }}
     {{- end }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -47,12 +47,13 @@
   <footer class="post-footer">
     {{- with .Params.tags }}
     <ul class="post-tags">
-      {{- range . }}
-      {{- $href := $.Site.GetPage (print "tags/" .)  }}
-      <li><a href="{{ $href.Permalink }}">{{ . }}</a></li>
-      {{- end }}
+      {{- range $index, $value := . }}
+      {{- $url := . | urlize | urls.Parse }}
+      {{- $tag := $url.Path | printf "/tags/%v" | $.Site.GetPage }}
+      <li><a href="{{ $tag.RelPermalink }}">{{ $tag.Title }}</a></li>
+      {{- end -}}
     </ul>
-    {{- end }}
+    {{- end -}}
     {{- if (and .Site.Params.ShowShareButtons (ne .Params.disableShare true) ) }}
     {{- partial "share_icons.html" . }}
     {{- end }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -45,14 +45,15 @@
     {{- partial "anchored_headings.html" .Content -}}
   </div>
   <footer class="post-footer">
-    {{- if .Params.tags }}
-    <ul class="post-tags">
-      {{- range .Params.tags }}
-      {{- $href := print (absLangURL "tags/") (urlize .) }}
-      <li><a href="{{ $href }}">{{ . }}</a></li>
-      {{- end }}
-    </ul>
-    {{- end }}
+    {{- with .Params.tags -}}
+      <ul class="post-tags">
+        {{- range $index, $value := . -}}
+        {{- $url := . | urlize | urls.Parse -}}
+        {{- $tag := $url.Path | printf "/tags/%v" | $.Site.GetPage -}}
+        <li><a href="{{ $tag.RelPermalink }}">{{ $tag.Title }}</a></li>
+        {{- end -}}
+      </ul>
+    {{- end -}}
     {{- if (and .Site.Params.ShowShareButtons (ne .Params.disableShare true) ) }}
     {{- partial "share_icons.html" . }}
     {{- end }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -51,9 +51,9 @@
       {{- $url := . | urlize | urls.Parse }}
       {{- $tag := $url.Path | printf "/tags/%v" | $.Site.GetPage }}
       <li><a href="{{ $tag.RelPermalink }}">{{ $tag.Title }}</a></li>
-      {{- end -}}
+      {{- end }}
     </ul>
-    {{- end -}}
+    {{- end }}
     {{- if (and .Site.Params.ShowShareButtons (ne .Params.disableShare true) ) }}
     {{- partial "share_icons.html" . }}
     {{- end }}


### PR DESCRIPTION
fix issue #112 
- allow custom permalink for taxonomies (tested on categories and tags)

example:
```
domain.com/tags/ #show all tags
domain.com/tags/foo -> domain.com/tag/foo  #for specific tag
```