### PR TITLE
Fix appending of '/' to menu item URLs

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -109,7 +109,7 @@
         {{- $currentPage := . }}
         <ul class="menu" id="menu" onscroll="menu_on_scroll()">
             {{- range .Site.Menus.main }}
-            {{- $menu_item_url := (cond (strings.HasSuffix .URL "/") .URL (printf "%s/" .URL) ) | absLangURL }}
+            {{- $menu_item_url := .URL | absLangURL }}
             {{- $page_url:= $currentPage.Permalink  | absLangURL }}
             <li>
                 <a href="{{ $menu_item_url }}">


### PR DESCRIPTION
Currently, menu item URLs automatically have a slash (`/`) appended to them. This is problematic if the resource they point to isn't supposed to have a trailing slash.

For example, on my website, I want a link to the RSS feed, which is located at `/blog/index.xml`. I set that as the URL for the menu item, but when generating, a slash (`/`) was appended, which turned it into `/blog/index.xml/`. This path is incorrect, and leads to a 404.

With this patch, menu item URLs don't have a slash appended. I tested it on same-site urls (like `/post/` and `/index.xml`) as well as full URLs (like `https://example.org`). Nothing seems to break.