### PR TITLE
Fix user defining canonical URL resulting in multiple canonical URLs

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -16,7 +16,7 @@
     {{- .Summary | default (printf "%s - %s" .Title  .Site.Title) }}{{- else }}
     {{- with .Site.Params.description }}{{ . }}{{- end }}{{- end }}{{- end -}}">
 <meta name="author" content="{{ (partial "author.html" . ) }}">
-<link rel="canonical" href="{{ .Permalink }}" />
+<link rel="canonical" href="{{ if .Params.canonicalURL -}} {{ .Params.canonicalURL }} {{- else -}} {{ .Permalink }} {{- end }}" />
 {{- if .Site.Params.analytics.google.SiteVerificationTag }}
 <meta name="google-site-verification" content="{{ .Site.Params.analytics.google.SiteVerificationTag }}" />
 {{- end}}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -17,10 +17,6 @@
     {{- with .Site.Params.description }}{{ . }}{{- end }}{{- end }}{{- end -}}">
 <meta name="author" content="{{ (partial "author.html" . ) }}">
 <link rel="canonical" href="{{ .Permalink }}" />
-{{- $canonical := cond (.IsHome) .Site.Params.canonical .Params.canonical }}
-{{- range $canonical }}
-<link rel="canonical" href="{{ trim . " " }}" />
-{{- end }}
 {{- if .Site.Params.analytics.google.SiteVerificationTag }}
 <meta name="google-site-verification" content="{{ .Site.Params.analytics.google.SiteVerificationTag }}" />
 {{- end}}


### PR DESCRIPTION
With 8af7c55: If the user defines a canonical URL, `head` will have multiple canonical URLs, which is improper. So, I'm reverting that commit in 6649bef.

With 12ea911: If the user defines a canonical URL, that URL will be used instead of the URL of the post.

N.B. This PR is basically the same as #104 which was opened by @Horsty80.

Closes: #130