### PR TITLE
CORS issue for multidomain setup fixed adityatelange/hugo-PaperMod#126

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -21,11 +21,11 @@
 {{- if (and (in site.Params.mainSections .Type) (ne .Layout `archives`) (ne .Layout `search`) (not $isHLJSdisabled)) }}
 {{- if not .Site.Params.assets.disableFingerprinting }}
 {{- $highlight := slice (resources.Get "js/highlight.min.js") | resources.Concat "assets/js/highlight.js" | minify | fingerprint }}
-<script defer src="{{ $highlight.Permalink }}" integrity="{{ $highlight.Data.Integrity }}"
+<script defer src="{{ $highlight.RelPermalink }}" integrity="{{ $highlight.Data.Integrity }}"
     onload="hljs.initHighlightingOnLoad();"></script>
 {{- else}}
 {{- $highlight := slice (resources.Get "js/highlight.min.js") | resources.Concat "assets/js/highlight.js" | minify }}
-<script defer src="{{ $highlight.Permalink }}" onload="hljs.initHighlightingOnLoad();"></script>
+<script defer src="{{ $highlight.RelPermalink }}" onload="hljs.initHighlightingOnLoad();"></script>
 {{- end}}
 {{- end }}
 <script>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -29,10 +29,10 @@
 
 {{- if not .Site.Params.assets.disableFingerprinting }}
 {{- $stylesheet := $stylesheet | fingerprint -}}
-<link href="{{ $stylesheet.Permalink }}" integrity="{{ $stylesheet.Data.Integrity }}" rel="preload stylesheet"
+<link href="{{ $stylesheet.RelPermalink }}" integrity="{{ $stylesheet.Data.Integrity }}" rel="preload stylesheet"
     as="style">
 {{- else}}
-<link href="{{ $stylesheet.Permalink }}" rel="preload stylesheet" as="style">
+<link href="{{ $stylesheet.RelPermalink }}" rel="preload stylesheet" as="style">
 {{- end}}
 <!-- Search -->
 {{- if (eq .Layout `search`) -}}
@@ -41,10 +41,10 @@
 {{- $fusejs := resources.Get "js/fuse.js" }}
 {{- if not .Site.Params.assets.disableFingerprinting }}
 {{- $search := (slice $fusejs $fastsearch ) | resources.Concat "assets/js/search.js" | minify | fingerprint }}
-<script defer src="{{ $search.Permalink }}" onload="loadSearch();" integrity="{{ $search.Data.Integrity }}"></script>
+<script defer src="{{ $search.RelPermalink }}" onload="loadSearch();" integrity="{{ $search.Data.Integrity }}"></script>
 {{- else}}
 {{ $search := (slice $fusejs $fastsearch ) | resources.Concat "assets/js/search.js" | minify }}
-<script defer src="{{ $search.Permalink }}" onload="loadSearch();"></script>
+<script defer src="{{ $search.RelPermalink }}" onload="loadSearch();"></script>
 {{- end}}
 {{- end -}}
 


### PR DESCRIPTION
Hi,

I stumbled upon an issue with the CORS similar to the #126 in multilingual mode with distinct domains assigned per language.
A similar case was described [here](https://github.com/gohugoio/hugo/issues/5226#issuecomment-438953402) and using `.RelPermalink` to load Hugo Pipes resources instead of just `Permalink` was the unanimously recommended workaround.

Tested it locally and on netlify, and it worked well.