### PR TITLE
Allow page-specific cover settings to override site-level settings.

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -31,7 +31,7 @@
     </div>
     {{- end}}
   </header>
-  {{- $isHidden := ((.Site.Params.cover.hidden | default .Site.Params.cover.hiddenInSingle) | default .Params.cover.hidden )}}
+  {{- $isHidden := .Params.cover.hidden | default .Site.Params.cover.hiddenInSingle | default .Site.Params.cover.hidden}}
   {{- partial "cover.html" (dict "cxt" . "IsHome" false "isHidden" $isHidden) }}
   {{- if (.Param "ShowToc") }}
   <div class="toc">


### PR DESCRIPTION
I want to have cover photos visible by default, but I have specific pages that I want to hide them on. I'd still like to specify the cover image on this page for the structured data, but I want to hide it from the standard view.

Here's the configuration I'd like to use:

Site-level `config.yml`:
```yaml
cover:
    hidden: false
    hiddenInSingle: false
```

Specific page front-matter:
```yaml
cover:
  image: "image.jpg"
  hidden: true
```

With the previous code, the site-level settings took precedence, resulting in a visible cover photo.
With this change, the page-level setting, if specified, always wins over site-level settings.


To test this, I verified each combination of these three settings, trying unset, `false`, and `true`, and found expected results for each scenario.