### PR TITLE
Add meta tag for yandex verification

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -20,6 +20,9 @@
 {{- if .Site.Params.analytics.google.SiteVerificationTag }}
 <meta name="google-site-verification" content="{{ .Site.Params.analytics.google.SiteVerificationTag }}" />
 {{- end}}
+{{- if .Site.Params.analytics.yandex.SiteVerificationTag }}
+<meta name="yandex-verification" content="{{ .Site.Params.analytics.yandex.SiteVerificationTag }}" />
+{{- end}}
 <!-- Styles -->
 {{- $common := (resources.Match "css/*.css") | resources.Concat "assets/css/common.css" }}
 {{- $extended := (resources.Match "css/extended/*.css") | resources.Concat "assets/css/extended.css" }}


### PR DESCRIPTION
Hi @adityatelange, 

I want to add a meta tag for Yandex Webmaster verification.

Here is example configuration of `config.yml` for adding Yandex Webmaster verification:

```yml
params:  
  analytics:
    yandex:
      SiteVerificationTag: xxxxxxxxxxxxxxxx
```

Thank you.