### PR TITLE
Add a meta tag for Bing verification

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -23,6 +23,9 @@
 {{- if .Site.Params.analytics.yandex.SiteVerificationTag }}
 <meta name="yandex-verification" content="{{ .Site.Params.analytics.yandex.SiteVerificationTag }}" />
 {{- end}}
+{{- if .Site.Params.analytics.bing.SiteVerificationTag }}
+<meta name="msvalidate.01" content="{{ .Site.Params.analytics.bing.SiteVerificationTag }}" />
+{{- end}}
 <!-- Styles -->
 {{- $common := (resources.Match "css/*.css") | resources.Concat "assets/css/common.css" }}
 {{- $extended := (resources.Match "css/extended/*.css") | resources.Concat "assets/css/extended.css" }}


### PR DESCRIPTION
I want to add a meta tag for Bing Webmaster verification.

Here is example configuration of `config.yml` for adding Bing Webmaster verification:

```yml
params:  
  analytics:
    bing:
      SiteVerificationTag: xxxxxxxxxxxxxxxx
```

Thank you.