### PR TITLE
Fixed missing reciprocal and self-reference hreflang

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -71,7 +71,7 @@
 {{- range .AlternativeOutputFormats -}}
 <link rel="{{ .Rel }}" type="{{ .MediaType.Type }}" href="{{ .Permalink | safeURL }}">
 {{ end -}}
-{{- range .Translations -}}
+{{- range .AllTranslations -}}
 <link rel="alternate" hreflang="{{- .Lang -}}" href="{{- .Permalink -}}" />
 {{ end }}
 {{- partial "extend_head.html" . -}}


### PR DESCRIPTION
Fixed 2 issues related to missing reciprocal hreflang and missing self-reference hreflang annotations. More details [here](https://help.ahrefs.com/en/articles/2631143-missing-reciprocal-hreflang-no-return-tag-error-in-site-audit) and [here](https://help.ahrefs.com/en/articles/2754344-what-does-the-self-referencing-hreflang-annotation-missing-issue-in-site-audit-mean).

![image](https://user-images.githubusercontent.com/4234384/106250874-e37a9500-621c-11eb-8ba2-55dc8845035b.png)
