### PR TITLE
Add support for gtag - Google Global Site Tag

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -82,4 +82,5 @@
 {{- template "partials/templates/opengraph.html" . }}
 {{- template "partials/templates/twitter_cards.html" . }}
 {{- template "partials/templates/schema_json.html" . }}
+{{- template "partials/templates/analytics_gtag.html" . }}
 {{- end }}

--- a/layouts/partials/templates/analytics_gtag.html
+++ b/layouts/partials/templates/analytics_gtag.html
@@ -1,0 +1,10 @@
+{{- if .Site.Params.googleGtag }}
+<!-- Global site tag (gtag.js) - Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id={{- .Params.googleGtag}}"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', "{{- .Params.googleGtag}}");
+</script>
+{{- end}}

--- a/layouts/partials/templates/analytics_gtag.html
+++ b/layouts/partials/templates/analytics_gtag.html
@@ -1,10 +1,10 @@
-{{- if .Site.Params.googleGtag }}
+{{- if .Site.Params.analytics.google.gtag }}
 <!-- Global site tag (gtag.js) - Google Analytics -->
-<script async src="https://www.googletagmanager.com/gtag/js?id={{- .Params.googleGtag}}"></script>
+<script async src="https://www.googletagmanager.com/gtag/js?id={{- .Site.Params.analytics.google.gtag }}"></script>
 <script>
   window.dataLayer = window.dataLayer || [];
   function gtag(){dataLayer.push(arguments);}
   gtag('js', new Date());
-  gtag('config', "{{- .Params.googleGtag}}");
+  gtag('config', "{{- .Site.Params.analytics.google.gtag}}");
 </script>
 {{- end}}


### PR DESCRIPTION
To enable gtag a param was added: `params.analytics.google.gtag`.

If the param is set, gtag will be added to the pages.