### PR TITLE
Redesign image captions

### DIFF
--- a/assets/css/post-single.css
+++ b/assets/css/post-single.css
@@ -246,7 +246,13 @@
     color: var(--primary);
     font-size: 16px;
     font-weight: bold;
-    margin: 24px 0 16px;
+    margin: 8px 0 16px;
+}
+
+.post-content figure > figcaption > p {
+	color: var(--secondary);
+	font-size: 14px;
+	font-weight: normal;
 }
 
 .toc {


### PR DESCRIPTION
Changes the style of image captions. This creates a distinciton between the `title` and `caption` attributes. The former now shows up more prominently than the latter. Both are centered below the image, which resolves #246.

Since there are no pages in the example site with images, I've added one in my fork's `exampleSite` branch: kdkasad@e7e62d98d4356c57bc9878e7cda8d5048f743f38. Below are screenshots of the various images on that page.

### Screenshots
#### Edit: captions are no longer centered. See [this comment](https://github.com/adityatelange/hugo-PaperMod/pull/247#issuecomment-781897919) for updated screenshots.

Cover image with caption:
![cover image](https://user-images.githubusercontent.com/63574107/108267331-e4b62800-711f-11eb-933f-71e12ca021b3.png)

Content image with title, caption, and attribution:
![image with title, caption, attr](https://user-images.githubusercontent.com/63574107/108267398-fe576f80-711f-11eb-899e-d5d8fe5c2300.png)

Content image with title and caption:
![image with title and caption](https://user-images.githubusercontent.com/63574107/108267486-1f1fc500-7120-11eb-9a9b-05a8ca641249.png)

Content image with title:
![image with title](https://user-images.githubusercontent.com/63574107/108267542-31016800-7120-11eb-90b7-219d09a77c2f.png)

Content image with caption:
![image with caption](https://user-images.githubusercontent.com/63574107/108267601-42e30b00-7120-11eb-835b-5cbcdb14b97f.png)
