### PR TITLE
enforce language url subsitution on path boundary

### DIFF
--- a/layouts/partials/breadcrumbs.html
+++ b/layouts/partials/breadcrumbs.html
@@ -1,7 +1,7 @@
 {{- if (.Param "ShowBreadCrumbs")}}
 <div class="breadcrumbs">
     {{- $url := replace .Parent.Permalink ( printf "%s" .Site.BaseURL) "" }}
-    {{- $lang_url := replace $url ( printf "%s" .Lang) "" }}
+    {{- $lang_url := strings.TrimPrefix ( printf "%s/" .Lang) $url }}
 
     <a href="{{ "" | absLangURL }}">{{ i18n "home" | default "Home"}}</a>
     {{- $scratch := newScratch }}

--- a/layouts/partials/templates/schema_json.html
+++ b/layouts/partials/templates/schema_json.html
@@ -19,7 +19,7 @@
 {{- else if (or .IsPage .IsSection) }}
 {{/* BreadcrumbList */}}
 {{- $url := replace .Parent.Permalink ( printf "%s" .Site.BaseURL) "" }}
-{{- $lang_url := replace $url ( printf "%s" .Lang) "" }}
+{{- $lang_url := strings.TrimPrefix ( printf "%s/" .Lang) $url }}
 {{- $bc_list := (split $lang_url "/")}}
 
 {{- $scratch := newScratch }}


### PR DESCRIPTION
Without this, the section name gets mangled when the language was a
  substring of the section.  For example, under 'en', a section named
  "fragment" changes to "fragmt".