### PR TITLE
Add 'align' option to figure shortcode

### DIFF
--- a/assets/css/post-single.css
+++ b/assets/css/post-single.css
@@ -243,9 +243,6 @@
 }
 
 .post-content figure.align-center {
-	display: flex;
-	flex-direction: column;
-	align-items: center;
 	text-align: center;
 }
 

--- a/assets/css/post-single.css
+++ b/assets/css/post-single.css
@@ -242,6 +242,13 @@
     margin: auto
 }
 
+.post-content figure.align-center {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	text-align: center;
+}
+
 .post-content figure > figcaption {
     color: var(--primary);
     font-size: 16px;

--- a/layouts/shortcodes/figure.html
+++ b/layouts/shortcodes/figure.html
@@ -1,6 +1,6 @@
-<figure{{ if or (.Get "class") (.Get "align") }} class="
-           {{- with .Get "align" }}align-{{ . }} {{ end }}
-           {{- with .Get "class" }}{{ . }}{{ end }}"
+<figure{{ if or (.Get "class") (eq (.Get "align") "center") }} class="
+           {{- if eq (.Get "align") "center" }}align-center {{ end }}
+           {{- with .Get "class" }}{{ . }}{{- end }}"
 {{- end -}}>
     {{- if .Get "link" -}}
         <a href="{{ .Get "link" }}"{{ with .Get "target" }} target="{{ . }}"{{ end }}{{ with .Get "rel" }} rel="{{ . }}"{{ end }}>

--- a/layouts/shortcodes/figure.html
+++ b/layouts/shortcodes/figure.html
@@ -5,7 +5,7 @@
     {{- if .Get "link" -}}
         <a href="{{ .Get "link" }}"{{ with .Get "target" }} target="{{ . }}"{{ end }}{{ with .Get "rel" }} rel="{{ . }}"{{ end }}>
     {{- end }}
-    <img src="{{ .Get "src" }}"
+    <img src="{{ .Get "src" }}{{- if eq (.Get "align") "center" }}#center{{- end }}"
          {{- if or (.Get "alt") (.Get "caption") }}
          alt="{{ with .Get "alt" }}{{ . }}{{ else }}{{ .Get "caption" | markdownify| plainify }}{{ end }}"
          {{- end -}}

--- a/layouts/shortcodes/figure.html
+++ b/layouts/shortcodes/figure.html
@@ -1,4 +1,7 @@
-<figure{{ with .Get "class" }} class="{{ . }}"{{ end }}>
+<figure{{ if or (.Get "class") (.Get "align") }} class="
+           {{- with .Get "align" }}align-{{ . }} {{ end }}
+           {{- with .Get "class" }}{{ . }}{{ end }}"
+{{- end -}}>
     {{- if .Get "link" -}}
         <a href="{{ .Get "link" }}"{{ with .Get "target" }} target="{{ . }}"{{ end }}{{ with .Get "rel" }} rel="{{ . }}"{{ end }}>
     {{- end }}


### PR DESCRIPTION
Allows centering figures (images) by adding an `align` parameter to the `figure` shortcode.

Adding `align=center` to a figure causes the resulting figure to be centered.

Example screenshot:
![image](https://user-images.githubusercontent.com/63574107/108608181-48d42880-737a-11eb-9f8a-bcc7c54f2132.png)
