### PR TITLE
Do not show ToC when it does not exist

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -21,7 +21,7 @@
   </header>
   {{- $isHidden := .Params.cover.hidden | default .Site.Params.cover.hiddenInSingle | default .Site.Params.cover.hidden}}
   {{- partial "cover.html" (dict "cxt" . "IsHome" false "isHidden" $isHidden) }}
-  {{- if (.Param "ShowToc") }}
+  {{- if and (.Param "ShowToc") (partial "toc.html" .) }}
   <div class="toc">
     <details {{if (.Param "TocOpen") }} open{{ end }}>
       <summary accesskey="c" title="(Alt + C)">


### PR DESCRIPTION
Hello, I've noticed that ToC shows up with an empy section when there are no headings exist and ShowToc is set to true.

I've fixed problem by adding `and` operator to `single.html` template. However I'm not sure what's the ideal option there. If something else needed, please point me out.

Best.

Before:
<img width="1077" alt="image" src="https://user-images.githubusercontent.com/5755154/109394516-b9a1b480-7927-11eb-9b16-23ecbf740a7f.png">

After:
<img width="1071" alt="image" src="https://user-images.githubusercontent.com/5755154/109394540-d50cbf80-7927-11eb-8c42-a6ac578d815c.png">
