### PR TITLE
Allow selective disabling of NavLinks in front matter

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -44,7 +44,7 @@
       {{- end }}
     </ul>
     {{- end }}
-    {{- if .Site.Params.ShowPostNavLinks }}
+    {{- if (.Param "ShowPostNavLinks") }}
     {{- $pages := where site.RegularPages "Type" "in" site.Params.mainSections }}
     {{- if and (gt (len $pages) 1) (in $pages . ) }}
     <nav class="paginav">


### PR DESCRIPTION
Previous style of getting params does not allow disabling this in front matter. With this change, the below can be done to disable nav links on a page. This change mirrors how ShowBreadCrumbs already works.

```
---
title: "About Book Project"
searchHidden: true
draft: false
ShowBreadCrumbs: false
ShowPostNavLinks: false
---
```