### PR TITLE
Add support for `rtl` and `ltr` shortcodes

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -49,7 +49,7 @@
       {{- if .Draft }}<div class="entry-isdraft"><sup>&nbsp;&nbsp;[draft]</sup></div>{{- end }}
     </h2>
   </header>
-  {{- if (ne .Site.Params.hideSummary true)}}
+  {{- if (ne (.Param "hideSummary") true)}}
   <section class="entry-content">
     <p>{{ .Summary | plainify | htmlUnescape }}...</p>
   </section>

--- a/layouts/shortcodes/ltr.html
+++ b/layouts/shortcodes/ltr.html
@@ -1,0 +1,15 @@
+{{ $.Scratch.Set "md" false }}
+
+{{ if .IsNamedParams }}
+{{ $.Scratch.Set "md" (.Get "md") }}
+{{ else }}
+{{ $.Scratch.Set "md" (.Get 0) }}
+{{ end }}
+
+<div dir="ltr">
+  {{ if eq ($.Scratch.Get "md") true }}
+    {{ .Inner | markdownify }}
+  {{ else }}
+    {{ .Inner }}
+  {{ end }}
+</div>

--- a/layouts/shortcodes/rtl.html
+++ b/layouts/shortcodes/rtl.html
@@ -1,0 +1,15 @@
+{{ $.Scratch.Set "md" false }}
+
+{{ if .IsNamedParams }}
+{{ $.Scratch.Set "md" (.Get "md") }}
+{{ else }}
+{{ $.Scratch.Set "md" (.Get 0) }}
+{{ end }}
+
+<div dir="rtl">
+  {{ if eq ($.Scratch.Get "md") true }}
+    {{ .Inner | markdownify }}
+  {{ else }}
+    {{ .Inner }}
+  {{ end }}
+</div>


### PR DESCRIPTION
This is to support `rtl` and `ltr` short-codes.

### Use Case:
You may need to insert some contents in a different direction compared to your main site direction so that these shortcodes will come in handy.

### Important notes:
- These shortcodes will support nested shortcodes by default so that they won't `markdownify` your contents!
- If you want to `markdownify` (support `md` in) your contents, you can set the `md` parameter to `true`.

### Examples:
```
{{< rtl >}}
{{< blockquote >}}

مرحبا بك

{{< /blockquote >}}
{{< /rtl >}}
```
This will result in a `blockquote` in `rtl`.

---

```
{{< rtl md=true >}}

> مرحبا بك

{{< /rtl >}}
```
This will result in `rtl` contents which rendered using `md`.

---


```
{{< rtl true >}}

> مرحبا بك

{{< /rtl }}
```
This will result in `rtl` contents which rendered using `md` (same example above, but with positional argument instead of a named argument in the content file).

---

The `ltr` shortcode could be used in the same way but in the context of an `rtl` website.

