### PR TITLE
Allow selective summary hiding in front matter

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -49,7 +49,7 @@
       {{- if .Draft }}<div class="entry-isdraft"><sup>&nbsp;&nbsp;[draft]</sup></div>{{- end }}
     </h2>
   </header>
-  {{- if (ne .Site.Params.hideSummary true)}}
+  {{- if (ne (.Param "hideSummary") true)}}
   <section class="entry-content">
     <p>{{ .Summary | plainify | htmlUnescape }}...</p>
   </section>


### PR DESCRIPTION
The previous style of getting params does not allow hiding post summary from the listing page in the front matter. With this change, the below can be done to hide the summary for a specific post or page. This change mirrors how `ShowBreadCrumbs` already works.

```
---
title: "Test Post"
hideSummary: true
---

post contents...
```