### PR TITLE
Add support for `rtl` and `ltr` shortcodes

### DIFF
--- a/layouts/shortcodes/ltr.html
+++ b/layouts/shortcodes/ltr.html
@@ -1,0 +1,15 @@
+{{ $.Scratch.Set "md" false }}
+
+{{ if .IsNamedParams }}
+{{ $.Scratch.Set "md" (.Get "md") }}
+{{ else }}
+{{ $.Scratch.Set "md" (.Get 0) }}
+{{ end }}
+
+<div dir="ltr">
+  {{ if eq ($.Scratch.Get "md") true }}
+    {{ .Inner | markdownify }}
+  {{ else }}
+    {{ .Inner }}
+  {{ end }}
+</div>

--- a/layouts/shortcodes/ltr.html
+++ b/layouts/shortcodes/ltr.html
@@ -7,9 +7,9 @@
 {{ end }}
 
 <div dir="ltr">
-  {{ if eq ($.Scratch.Get "md") true }}
-    {{ .Inner | markdownify }}
-  {{ else }}
+  {{ if eq ($.Scratch.Get "md") false }}
     {{ .Inner }}
+  {{ else }}
+    {{ .Inner | markdownify }}
   {{ end }}
 </div>

--- a/layouts/shortcodes/rtl.html
+++ b/layouts/shortcodes/rtl.html
@@ -7,9 +7,9 @@
 {{ end }}
 
 <div dir="rtl">
-  {{ if eq ($.Scratch.Get "md") true }}
-    {{ .Inner | markdownify }}
-  {{ else }}
+  {{ if eq ($.Scratch.Get "md") false }}
     {{ .Inner }}
+  {{ else }}
+    {{ .Inner | markdownify }}
   {{ end }}
 </div>

--- a/layouts/shortcodes/rtl.html
+++ b/layouts/shortcodes/rtl.html
@@ -1,0 +1,15 @@
+{{ $.Scratch.Set "md" false }}
+
+{{ if .IsNamedParams }}
+{{ $.Scratch.Set "md" (.Get "md") }}
+{{ else }}
+{{ $.Scratch.Set "md" (.Get 0) }}
+{{ end }}
+
+<div dir="rtl">
+  {{ if eq ($.Scratch.Get "md") true }}
+    {{ .Inner | markdownify }}
+  {{ else }}
+    {{ .Inner }}
+  {{ end }}
+</div>


### PR DESCRIPTION
This is to support `rtl` and `ltr` short-codes.

### Use Case:
You may need to insert some contents in a different direction compared to your main site direction so that these shortcodes will come in handy.

### Important notes:
- These shortcodes will support `md` by default.
- If you want to include sub-shortcodes, you can set the `md` parameter to `false`.

### Examples:
```
{{< rtl >}}

> مرحبا بك

{{< /rtl >}}
```
This will result in `rtl` contents rendered using `md`.

---

```
{{< rtl md=false >}}
{{< blockquote >}}

مرحبا بك

{{< /blockquote >}}
{{< /rtl >}}
```
This will result in a `blockquote` in `rtl`.

---

```
{{< rtl false >}}
{{< blockquote >}}

مرحبا بك

{{< /blockquote >}}
{{< /rtl >}}
```
This will result in a `blockquote` in `rtl` (same example above, but with positional argument instead of a named argument in the content file).


---

The `ltr` shortcode could be used in the same way but in the context of an `rtl` website.

