### PR TITLE
Add hideDescription param

### DIFF
--- a/layouts/_default/archives.html
+++ b/layouts/_default/archives.html
@@ -2,10 +2,12 @@
 
 <header class="page-header">
   <h1>{{ .Title }}</h1>
-  {{- if .Description }}
-  <div class="post-description">
-    {{ .Description }}
-  </div>
+  {{- if not (.Param "hideDescription") }}
+    {{- if .Description }}
+    <div class="post-description">
+      {{ .Description }}
+    </div>
+    {{- end }}
   {{- end }}
 </header>
 

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -8,10 +8,12 @@
 <header class="page-header">
   {{- partial "breadcrumbs.html" . }}
   <h1>{{ .Title }}</h1>
-  {{- if .Description }}
-  <div class="post-description">
-    {{ .Description }}
-  </div>
+  {{- if not (.Param "hideDescription") }}
+    {{- if .Description }}
+    <div class="post-description">
+      {{ .Description }}
+    </div>
+    {{- end }}
   {{- end }}
 </header>
 {{- end }}
@@ -49,7 +51,7 @@
       {{- if .Draft }}<div class="entry-isdraft"><sup>&nbsp;&nbsp;[draft]</sup></div>{{- end }}
     </h2>
   </header>
-  {{- if (ne .Site.Params.hideSummary true)}}
+  {{- if (ne (.Param "hideSummary") true)}}
   <section class="entry-content">
     <p>{{ .Summary | plainify | htmlUnescape }}...</p>
   </section>

--- a/layouts/_default/search.html
+++ b/layouts/_default/search.html
@@ -8,10 +8,12 @@
             <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
         </svg>
     </h1>
-    {{- if .Description }}
-    <div class="post-description">
+    {{- if not (.Param "hideDescription") }}
+      {{- if .Description }}
+      <div class="post-description">
         {{ .Description }}
-    </div>
+      </div>
+      {{- end }}
     {{- end }}
     {{- if not (.Param "hideMeta") }}
     <div class="post-meta">

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -7,10 +7,12 @@
       {{ .Title }}
       {{- if .Draft }}<div class="entry-isdraft"><sup>&nbsp;&nbsp;[draft]</sup></div>{{- end }}
     </h1>
-    {{- if .Description }}
-    <div class="post-description">
-      {{ .Description }}
-    </div>
+    {{- if not (.Param "hideDescription") }}
+      {{- if .Description }}
+      <div class="post-description">
+        {{ .Description }}
+      </div>
+      {{- end }}
     {{- end }}
     {{- if not (.Param "hideMeta") }}
     <div class="post-meta">

--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -3,10 +3,12 @@
 {{- if .Title }}
 <header class="page-header">
     <h1>{{ .Title }}</h1>
-    {{- if .Description }}
-    <div class="post-description">
+    {{- if not (.Param "hideDescription") }}
+      {{- if .Description }}
+      <div class="post-description">
         {{ .Description }}
-    </div>
+      </div>
+      {{- end }}
     {{- end }}
 </header>
 {{- end }}


### PR DESCRIPTION
This change makes showing the description optional. With hideDescription
param it is possible to provide a custom description for a <head>
without displaying the description on a given page.