### PR TITLE
Remove space before robots meta name

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -4,7 +4,7 @@
 {{- if hugo.IsProduction | or (eq .Site.Params.env "production") }}
 <meta name="robots" content="index, follow">
 {{- else }}
-<meta name=" robots" content="noindex, nofollow">
+<meta name="robots" content="noindex, nofollow">
 {{- end -}}
 <!-- Title -->
 <title>{{ if .IsHome }}{{else}}{{ if .Title }}{{ .Title }} | {{ end }}{{end}}{{ .Site.Title }}</title>


### PR DESCRIPTION
For non production build, the meta "robots" has an extra space 