### PR TITLE
Use CSS to detect preferred color scheme when JS is disabled

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -44,7 +44,24 @@
         .top-link {
             display: none;
         }
-
+        {{- if (and (ne .Site.Params.defaultTheme "light") (ne .Site.Params.defaultTheme "dark")) }}
+        @media (prefers-color-scheme: dark) {
+            :root {
+                --theme: #1d1e20;
+                --entry: #2e2e33;
+                --primary: rgba(255, 255, 255, 0.84);
+                --secondary: rgba(255, 255, 255, 0.56);
+                --tertiary: rgba(255, 255, 255, 0.16);
+                --content: rgba(255, 255, 255, 0.74);
+                --hljs-bg: #2e2e33;
+                --code-bg: #37383e;
+                --border: #333;
+            }
+            .list {
+                background: var(--theme);
+            }
+        }
+        {{- end }}
     </style>
 </noscript>
 <header class="header">


### PR DESCRIPTION
If the site's theme is set to `auto`, CSS media queries will be used to set the dark theme based on the user's browser preferences when JavaScript is disabled. No change happens if JavaScript is enabled.