### PR TITLE
Updated head.html for SEO

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -9,6 +9,9 @@
 <!-- Title -->
 <title>{{ if .IsHome }}{{else}}{{ if .Title }}{{ .Title }} | {{ end }}{{end}}{{ .Site.Title }}</title>
 <!-- Meta -->
+<meta name="keywords" content="{{ if .Site.Params.keywords -}}
+    {{- range $i, $e := .Site.Params.keywords }}{{ if $i }}, {{ end }}{{ $e }}{{ end }} {{- else }}
+    {{- range $i, $e := .Params.tags }}{{ if $i }}, {{ end }}{{ $e }}{{ end }} {{- end -}}" />
 <meta name="keywords" content="{{ if .Params.keywords -}}
     {{- range $i, $e := .Params.keywords }}{{ if $i }}, {{ end }}{{ $e }}{{ end }} {{- else }}
     {{- range $i, $e := .Params.tags }}{{ if $i }}, {{ end }}{{ $e }}{{ end }} {{- end -}}" />


### PR DESCRIPTION
Added site-wide keywords for SEO, this will enable to add keywords scoped to the entire website.
For example, if the site is a personal blog of david john , this will allow adding keywords in site params
```yaml
params:
   keywords: ["david","david john","david john blog"]

```
