### PR TITLE
Fix scrollbar track background in dark mode caused by #308

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -60,6 +60,12 @@
             .list {
                 background: var(--theme);
             }
+            .list:not(.dark)::-webkit-scrollbar-track {
+                background: 0 0;
+            }
+            .list:not(.dark)::-webkit-scrollbar-thumb {
+                border-color: var(--theme);
+            }
         }
         {{- end }}
     </style>


### PR DESCRIPTION
#308 added dark mode detection without JS, but failed to override the scrollbar color. This fixes that.