### PR TITLE
Fix color of "Name" class in Code Highlighting with light background

### DIFF
--- a/assets/css/post-single.css
+++ b/assets/css/post-single.css
@@ -210,7 +210,7 @@
     display: block;
     margin: auto 0;
     padding: 10px;
-    color: rgba(255, 255, 255, .8);
+    color: var(--primary);
     background: 0 0;
     border-radius: 0;
     overflow-x: auto;


### PR DESCRIPTION
When using the "chroma styles" classes (via `hugo gen chromastyles --style=github > assets/css/extended/syntax.css`), the `css` for _Names_ is just

```css
.chroma .n {  }
```

That means the text will be coloured by this part:
https://github.com/adityatelange/hugo-PaperMod/blob/b6af9eddee7f816b01a68836344b36d30de4a492/assets/css/post-single.css#L209-L218

For chroma styles with a _light_ background, this is not readable (basically white on white).

This fix uses the `--primary` colour, so black for the light and white for the dark mode.