### PR TITLE
Fix path in editPost URL for Windows

### DIFF
--- a/layouts/partials/edit_post.html
+++ b/layouts/partials/edit_post.html
@@ -1,6 +1,7 @@
 {{- if or .Params.editPost.URL .Site.Params.editPost.URL -}}
+{{- $fileUrlPath := path.Join .File.Path }}
 {{- if or .Params.author $.Site.Params.author (.Param "ShowReadingTime") (not .Date.IsZero) .IsTranslated }}|&nbsp;{{- end -}}
-<a href="{{ .Params.editPost.URL | default .Site.Params.editPost.URL }}{{ if .Params.editPost.appendFilePath | default ( .Site.Params.editPost.appendFilePath | default false ) }}/{{ .File.Path }}{{ end }}" rel="noopener noreferrer" target="_blank">
+<a href="{{ .Params.editPost.URL | default .Site.Params.editPost.URL }}{{ if .Params.editPost.appendFilePath | default ( .Site.Params.editPost.appendFilePath | default false ) }}/{{ $fileUrlPath }}{{ end }}" rel="noopener noreferrer" target="_blank">
     {{- .Params.editPost.Text | default (.Site.Params.editPost.Text | default (i18n "edit_post" | default "Edit") ) -}}
 </a>
 {{- end }}


### PR DESCRIPTION
`.File.Path` is OS dependant and uses `\` as directory separator. This leads to
cases where posts get the wrong URL, if in a sub folder, e.g.
`content/posts/folder\post.md`.

One idea was to replace `\` with `/` this however breaks valid files (on Unix
systems) which include `\` in the file name.
According to the docs [`path.Join`](layouts/partials/edit_post.html) is OS
unaware and converts to a Unix-like path.

> Note: All path elements on Windows are converted to slash ('/') separators.

PS: It looks like hugo also uses this internally to build URLs.
PPS: Solution was discussed in #278.