### PR TITLE
remove .Site.Authors references

### DIFF
--- a/layouts/partials/templates/opengraph.html
+++ b/layouts/partials/templates/opengraph.html
@@ -30,13 +30,11 @@
 {{ with .PublishDate }}<meta property="article:published_time" content="{{ .Format $iso8601 }}" />{{ end }}
 {{ with .Lastmod }}<meta property="article:modified_time" content="{{ .Format $iso8601 }}" />{{ end }}
 
-{{- range .Site.Authors }}
-{{ with .Social.facebook }}<meta property="article:author" content="https://www.facebook.com/{{ . }}" />{{ end }}
+{{ with .Site.Social.facebook }}<meta property="article:author" content="https://www.facebook.com/{{ . }}" />{{ end }}
 {{ with .Site.Social.facebook }}<meta property="article:publisher" content="https://www.facebook.com/{{ . }}" />{{ end }}
 {{- with .Params.tags }}{{ range first 6 . }}
 <meta property="article:tag" content="{{ . }}" />
 {{- end }}{{ end -}}
-{{- end -}}
 {{- end -}}
 
 {{- with .Params.audio }}<meta property="og:audio" content="{{ . }}" />{{ end }}

--- a/layouts/partials/templates/twitter_cards.html
+++ b/layouts/partials/templates/twitter_cards.html
@@ -30,9 +30,5 @@
 <meta name="twitter:description" content="{{ with .Description }}{{ . }}{{ else }}{{if .IsPage}}{{ .Summary }}{{ else }}{{ with .Site.Params.description }}{{ . }}{{ end }}{{ end }}{{ end -}}"/>
 {{ with .Site.Social.twitter -}}
 <meta name="twitter:site" content="@{{ . }}"/>
-{{ end -}}
-{{ range .Site.Authors }}
-{{ with .twitter -}}
 <meta name="twitter:creator" content="@{{ . }}"/>
-{{ end -}}
 {{ end -}}


### PR DESCRIPTION
## About the Edits
This is a small edit to the Opengraph and Twitter Card templates to remove the `.Site.Authors` references which is an unimplemented feature and also absent in Hugo Documentation. `.Site.Authors` value cannot be set under any circumstances.

Until Hugo clarifies this further, this should fix the problem.

It solves this #340 

Other references of the issue:
- https://discourse.gohugo.io/t/how-do-i-setup-the-authors-key-in-the-config-file-for-twitter-creator-and-article-author-meta-tags/32102
- https://github.com/gohugoio/hugo/pull/8344
- https://github.com/gohugoio/hugo/issues/4458

## How is the issue solved?
Since `.Site.Authors` cannot be set, `twitter:creator` meta tag never renders. Same is the case with the `article:author` tag. The following changes fix the issue by getting the account handles from `.Site.Social` instead.