### PR TITLE
Move post nav links to a partial section

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -37,25 +37,7 @@
     </ul>
     {{- end }}
     {{- if (.Param "ShowPostNavLinks") }}
-    {{- $pages := where site.RegularPages "Type" "in" site.Params.mainSections }}
-    {{- if and (gt (len $pages) 1) (in $pages . ) }}
-    <nav class="paginav">
-      {{- with $pages.Next . }}
-      <a class="prev" href="{{ .Permalink }}">
-        <span class="title">« {{ i18n "prev_page" }}</span>
-        <br>
-        <span>{{- .Name -}}</span>
-      </a>
-      {{- end }}
-      {{- with $pages.Prev . }}
-      <a class="next" href="{{ .Permalink }}">
-        <span class="title">{{ i18n "next_page" }} »</span>
-        <br>
-        <span>{{- .Name -}}</span>
-      </a>
-      {{- end }}
-    </nav>
-    {{- end }}
+    {{- partial "post_nav_links.html" . }}
     {{- end }}
     {{- if (and .Site.Params.ShowShareButtons (ne .Params.disableShare true)) }}
     {{- partial "share_icons.html" . -}}

--- a/layouts/partials/post_nav_links.html
+++ b/layouts/partials/post_nav_links.html
@@ -1,0 +1,19 @@
+{{- $pages := where site.RegularPages "Type" "in" site.Params.mainSections }}
+{{- if and (gt (len $pages) 1) (in $pages . ) }}
+<nav class="paginav">
+  {{- with $pages.Next . }}
+  <a class="prev" href="{{ .Permalink }}">
+    <span class="title">« {{ i18n "prev_page" }}</span>
+    <br>
+    <span>{{- .Name -}}</span>
+  </a>
+  {{- end }}
+  {{- with $pages.Prev . }}
+  <a class="next" href="{{ .Permalink }}">
+    <span class="title">{{ i18n "next_page" }} »</span>
+    <br>
+    <span>{{- .Name -}}</span>
+  </a>
+  {{- end }}
+</nav>
+{{- end }}


### PR DESCRIPTION
This will allow easier overrides for post nav links without the need of overriding the entire "single" template.