### PR TITLE
Add buttons to copy code block contents

### DIFF
--- a/assets/css/common/main.css
+++ b/assets/css/common/main.css
@@ -52,15 +52,14 @@ div.highlight {
     display: none;
     position: absolute;
     top: 4px;
-    right: 16px;
-    color: var(--secondary);
+    right: 4px;
+    color: rgba(255, 255, 255, 0.8);
+    background: rgba(78, 78, 78, 0.8);
+    border-radius: var(--radius);
+    padding: 0 5px;
+    font-size: 14px;
 }
 
 div.highlight:hover .copy-code {
     display: block;
-}
-
-.copy-code:hover {
-    cursor: pointer;
-    text-decoration: underline;
 }

--- a/assets/css/common/main.css
+++ b/assets/css/common/main.css
@@ -41,5 +41,21 @@
 }
 
 code {
-    direction: ltr
+    direction: ltr;
+}
+
+div.highlight {
+    position: relative;
+}
+
+.copy-code {
+    position: absolute;
+    top: 4px;
+    right: 16px;
+    color: var(--secondary);
+}
+
+.copy-code:hover {
+    cursor: pointer;
+    text-decoration: underline;
 }

--- a/assets/css/common/main.css
+++ b/assets/css/common/main.css
@@ -49,10 +49,15 @@ div.highlight {
 }
 
 .copy-code {
+    display: none;
     position: absolute;
     top: 4px;
     right: 16px;
     color: var(--secondary);
+}
+
+div.highlight:hover .copy-code {
+    display: block;
 }
 
 .copy-code:hover {

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -18,8 +18,8 @@
 - id: home
   translation: "Home"
 
-- id: copy
+- id: code_copy
   translation: "copy"
 
-- id: copied
+- id: code_copied
   translation: "copied!"

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -17,3 +17,9 @@
 
 - id: home
   translation: "Home"
+
+- id: copy
+  translation: "copy"
+
+- id: copied
+  translation: "copied!"

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -104,12 +104,12 @@
 
         const copybutton = document.createElement('button');
         copybutton.classList.add('copy-code');
-            copybutton.innerText = '{{- i18n "copy" | default "copy" }}';
+        copybutton.innerText = '{{- i18n "code_copy" | default "copy" }}';
 
         function copyingDone() {
-            copybutton.innerText = '{{- i18n "copied" | default "copied!" }}';
+            copybutton.innerText = '{{- i18n "code_copied" | default "copied!" }}';
             setTimeout(() => {
-                copybutton.innerText = '{{- i18n "copy" | default "copy" }}';
+                copybutton.innerText = '{{- i18n "code_copy" | default "copy" }}';
             }, 2000);
         }
 
@@ -128,7 +128,7 @@
             try {
                 document.execCommand('copy');
                 copyingDone();
-            } catch (e) {};
+            } catch (e) { };
             selection.removeRange(range);
         });
 

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -96,3 +96,34 @@
 
 </script>
 {{- end }}
+
+{{- if (not .Site.Params.disableCodeCopy) }}
+<script>
+    document.querySelectorAll('pre > code').forEach((codeblock) => {
+        const container = codeblock.parentNode.parentNode;
+
+        const copybutton = document.createElement('div');
+        copybutton.classList.add('copy-code');
+        copybutton.innerHTML = 'copy';
+
+        copybutton.addEventListener('click', (cb) => {
+            if ('clipboard' in navigator) {
+                navigator.clipboard.writeText(codeblock.textContent);
+                return;
+            }
+
+            const range = document.createRange();
+            range.selectNodeContents(codeblock);
+            const selection = window.getSelection();
+            selection.removeAllRanges();
+            selection.addRange(range);
+            try {
+                document.execCommand('copy');
+            } catch (e) {};
+            selection.removeRange(range);
+        });
+
+        container.appendChild(copybutton);
+    });
+</script>
+{{- end }}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -102,9 +102,9 @@
     document.querySelectorAll('pre > code').forEach((codeblock) => {
         const container = codeblock.parentNode.parentNode;
 
-        const copybutton = document.createElement('div');
+        const copybutton = document.createElement('button');
         copybutton.classList.add('copy-code');
-        copybutton.innerHTML = 'copy';
+        copybutton.innerText = 'copy';
 
         function copyingDone() {
             copybutton.innerText = 'copied!';

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -106,9 +106,17 @@
         copybutton.classList.add('copy-code');
         copybutton.innerHTML = 'copy';
 
+        function copyingDone() {
+            copybutton.innerText = 'copied!';
+            setTimeout(() => {
+                copybutton.innerText = 'copy';
+            }, 2000);
+        }
+
         copybutton.addEventListener('click', (cb) => {
             if ('clipboard' in navigator) {
                 navigator.clipboard.writeText(codeblock.textContent);
+                copyingDone();
                 return;
             }
 
@@ -119,6 +127,7 @@
             selection.addRange(range);
             try {
                 document.execCommand('copy');
+                copyingDone();
             } catch (e) {};
             selection.removeRange(range);
         });

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -104,12 +104,12 @@
 
         const copybutton = document.createElement('button');
         copybutton.classList.add('copy-code');
-        copybutton.innerText = 'copy';
+            copybutton.innerText = '{{- i18n "copy" | default "copy" }}';
 
         function copyingDone() {
-            copybutton.innerText = 'copied!';
+            copybutton.innerText = '{{- i18n "copied" | default "copied!" }}';
             setTimeout(() => {
-                copybutton.innerText = 'copy';
+                copybutton.innerText = '{{- i18n "copy" | default "copy" }}';
             }, 2000);
         }
 


### PR DESCRIPTION
Adds a clickable "copy" link in the top-right corner of each code block.

If available, uses the navigator.clipboard API. Falls back to selecting
the text and calling document.execCommand('copy') to copy text.

I mainly focused on functionality, not style, so let me know if you want it to look different.

I tested on both Chrome and Firefox on Linux, and it works using both the `navigator.clipboard` API and the fallback method in both browsers.

Closes #344 