### PR TITLE
🐛 add missing spacing between title and icon

### DIFF
--- a/layouts/_default/search.html
+++ b/layouts/_default/search.html
@@ -1,7 +1,7 @@
 {{- define "main" }}
 
 <header class="page-header">
-    <h1>{{ .Title }}
+    <h1>{{ .Title }}&nbsp;
         <svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 24 24" fill="none"
             stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <circle cx="11" cy="11" r="8"></circle>


### PR DESCRIPTION
Currently there isn't any spacing betweent the headline on the search page and the svg search icon. Fixed this through adding a non breaking-space.

Current behaviour:
![image](https://user-images.githubusercontent.com/39946364/114317522-c873ad80-9b08-11eb-9a7e-381023b264cf.png)

After insert of nbsp:
![image](https://user-images.githubusercontent.com/39946364/114317510-b560dd80-9b08-11eb-977e-09c6b1d5d122.png)
