### PR TITLE
Fix Error: add site dependencies: load resources: loading templates: "site/themes/hugo-PaperMod/layouts/partials/head.html:79:1": parse failed: template: partials/head.html:79: unexpected unclosed action in command

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -76,8 +76,7 @@
 {{- $isHLJSdisabled := (.Site.Params.assets.disableHLJS | default .Params.disableHLJS ) }}
 {{- if (and (eq .Kind "page") (ne .Layout "archives") (ne .Layout "search") (not $isHLJSdisabled)) }}
 {{- if not .Site.Params.assets.disableFingerprinting }}
-{{- $highlight := slice (resources.Get "js/highlight.min.js") | resources.Concat "assets/js/highlight.js" | minify |
-fingerprint }}
+{{- $highlight := slice (resources.Get "js/highlight.min.js") | resources.Concat "assets/js/highlight.js" | minify | fingerprint }}
 <script defer crossorigin="anonymous" src="{{ $highlight.RelPermalink }}" integrity="{{ $highlight.Data.Integrity }}"
     onload="hljs.initHighlightingOnLoad();"></script>
 {{- else }}


### PR DESCRIPTION
Join lines to prevent the following error from being received:

`Error: add site dependencies: load resources: loading templates: "site/themes/hugo-PaperMod/layouts/partials/head.html:79:1": parse failed: template: partials/head.html:79: unexpected unclosed action in command`

NB: AFAICT, Hugo versions 0.81.0 and higher will not produce this error since those versions support newlines in template actions and commands. See: https://gohugo.io/news/0.81.0-relnotes/#newlines-in-template-actions-and-commands