### PR TITLE
Custom alt title in multilingual mode

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -123,7 +123,7 @@
                     {{- range . -}}
                     {{- if ne $lang .Lang }}
                     <li>
-                        <a href="{{- .Permalink -}}" title="{{ .Language.LanguageName | default (.Lang | humanize) }}"
+                        <a href="{{- .Permalink -}}" title="{{ .Language.Params.languageAltTitle | default (.Language.LanguageName | emojify) | default (.Lang | humanize) }}"
                             aria-label="{{ .Language.LanguageName | default (.Lang | humanize) }}">
                             {{- if (and $.Site.Params.displayFullLangName (.Language.LanguageName)) }}
                             {{- .Language.LanguageName | emojify -}}


### PR DESCRIPTION
Hi @adityatelange,

I would like to propose two minor tweaks in multilingual mode:

**1. Custom alt title**

Currently, when someone uses emoji like 🇬🇧 as languageName, PaperMod renders the alt title "as-is" (i.e. `:gb:`). In other words, it displays actual value from config ... which is not great. To go around this, I suggest to introduce a new optional param _languageAltTitle_ in the "languages" section so the user could customise what is displayed.

For example:

```
languages:
  en:
    languageName: ":gb:"
    languageAltTitle: "English"
    ...
```
This will render a country flag 🇬🇧 with alt title "English".

**2. Fallback to emoji**

I suggest to add a fallback option to "emojify" the alt title. This way, if the User does not want to customise anything, PaperMod could still render emoji in the alt title properly.

You can preview the change at [https://www.geeqla.com](https://www.geeqla.com)

Thank you!