### PR TITLE
Python Script to fetch details of Git projects and display on blog

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -32,6 +32,16 @@ jobs:
         with:
           hugo-version: 'latest'
 
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install requests pyyaml
+      - name: Fetch GitHub stars
+        run: |
+          python scripts/fetch-github-stars.py data/projectsGit.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.TOKEN }}
+          
       - name: Build
         run: hugo --buildDrafts --gc --verbose --minify
 

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -38,10 +38,10 @@ jobs:
           pip install requests pyyaml
       - name: Fetch GitHub stars
         run: |
-          python scripts/fetch-github-stars.py data/projectsGit.yml
+          python scripts/fetch-github-stars.py data/projects.yml
         env:
           GITHUB_TOKEN: ${{ secrets.TOKEN }}
-          
+
       - name: Build
         run: hugo --buildDrafts --gc --verbose --minify
 

--- a/data/projects.yml
+++ b/data/projects.yml
@@ -1,0 +1,28 @@
+- description: freeCodeCamp.org's open source codebase and curriculum. Learn to code for free.
+  github_uri: freeCodeCamp/freeCodeCamp
+  name: Free code camp
+  stars: 0
+  updated_at: '2021-03-31T17:59:49Z'
+  url: https://github.com/freeCodeCamp/freeCodeCamp
+  homepage: https://contribute.freecodecamp.org
+- description: 📚 Freely available programming books
+  github_uri: EbookFoundation/free-programming-books
+  name: EbookFoundation
+  stars:  0
+  updated_at: '2021-03-31T17:59:49Z'
+  url: https://github.com/EbookFoundation/free-programming-books
+  homepage: https://ebookfoundation.github.io/free-programming-books/
+- description: The most popular HTML, CSS, and JavaScript framework for developing responsive, mobile first projects on the web.
+  github_uri: twbs/bootstrap
+  name: bootstrap project
+  stars:  0
+  updated_at: '2021-03-31T17:59:49Z'
+  url: https://github.com/twbs/bootstrap
+  homepage: https://getbootstrap.com/
+- description: A curated list of awesome Python frameworks, libraries, software and resources.
+  github_uri: vinta/awesome-python
+  name: Python framework
+  stars:  0
+  updated_at: '2021-03-31T17:59:49Z'
+  url: https://github.com/vinta/awesome-python
+  homepage: https://awesome-python.com/

--- a/layouts/shortcodes/projects.html
+++ b/layouts/shortcodes/projects.html
@@ -1,0 +1,16 @@
+<ul class="projects">
+    {{ range sort .Page.Site.Data.projects ".stars" "desc" }}
+        <li class="item">
+            <div class="name">
+                <h3><a href="{{ .url }}">{{ .name }}</a></h3>
+                <h4 class="stars">Stars: ★ {{ .stars }}</h4>
+                <h4 class="lastmod">Last Modified: {{ .updated_at }}</h4>
+            </div>
+            <div class="description">
+                <p>{{ .description }}</p>
+            </div>
+            <h4 class="homepage">Link to access: <a href="{{ .homepage }}">{{ .homepage }}</a></h4>
+        </li>
+        <hr>
+    {{ end }}
+</ul>

--- a/scripts/fetch-github-stars.py
+++ b/scripts/fetch-github-stars.py
@@ -1,0 +1,53 @@
+#!/bin/python
+"""
+This script reads the Hugo data/projects.json lists file, fetches the Github
+project metadata and updates the file.
+"""
+import sys
+import yaml
+import json
+import requests
+from os import getenv
+from requests.auth import HTTPBasicAuth
+
+
+def fetch_project(url):
+    pass
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        sys.exit("provide path to projects.yml")
+
+    api_token = getenv("TOKEN", "")
+    if not api_token:
+        sys.exit("TOKEN is missing")
+
+    # Source: https://stackoverflow.com/a/1774043
+    with open(sys.argv[1], "r") as stream:
+        try:
+            projects = yaml.safe_load(stream)
+        except yaml.YAMLError as exc:
+            sys.exit(exc)
+
+    for i, p in enumerate(projects):
+        if "github_uri" not in p:
+            continue
+        print(p["github_uri"])
+
+        headers = {"Authorization": "token %s" % api_token}
+        url = "https://api.github.com/repos/{}".format(p["github_uri"])
+        r = requests.get(url, headers=headers)
+        # auth=HTTPBasicAuth("", ""))
+        data = json.loads(r.content)
+
+        # Update URLs.
+        projects[i]["name"] = data["name"]
+        projects[i]["url"] = "https://github.com/" + p["github_uri"]
+        projects[i]["description"] = data["description"]
+        projects[i]["stars"] = data["stargazers_count"]
+        projects[i]["updated_at"] = data["updated_at"]
+        projects[i]["homepage"] = data["homepage"]
+
+    with open(sys.argv[1], "w") as f:
+        yaml.dump(projects, f)


### PR DESCRIPTION
This python script reads the data/projects.yml lists file, fetches the Github project metadata mentioned in the file, and updates the file using Github Action. This helps the blogger to automatically update the blog with the latest repository information. For demo purpose, I have added details of a few popular open-source repositories. Inspiration from Zerodha tech blog - https://zerodha.tech/projects/ 