### PR TITLE
Make copyright txt consistent with nav label

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -2,7 +2,7 @@
     {{- if .Site.Copyright }}
     <span>{{ .Site.Copyright | markdownify }}</span>
     {{- else }}
-    <span>&copy; {{ now.Year }} <a href="{{ "" | absLangURL }}">{{ .Site.Title }}</a></span>
+    <span>&copy; {{ now.Year }} <a href="{{ "" | absLangURL }}">{{- .Site.Params.label.text | default .Site.Title }}</a></span>
     {{- end }}
     <span>&middot;</span>
     <span>Powered by <a href="https://gohugo.io/" rel="noopener noreferrer" target="_blank">Hugo</a></span>


### PR DESCRIPTION
Hi @adityatelange 👋 

In _layouts/partials/header.html_ we have: `{{- $label_text := (.Site.Params.label.text | default .Site.Title) }}`. In other words, users are free to use different copy for site title and main nav label. This is very handy.

Then, in _layouts/partials/footer.html_ we have: `{{ .Site.Title }}`. In other words, If the User decides to use custom main nav label in the header, PaperMod will (still) default to site title in the copyright line. Say, if I use something crazy as my site title (i.e. "My super home page!"), it will display "(c) 2021 My super home page!" in the footer ... which is not great.

I propose to we make header and footer to play in tandem. This way, users can set whatever site title they want and, yet, keep main nav label consistent with copyright line in the footer.

Preview: https://www.geeqla.com
Configuration file: https://github.com/geeqla/geeqla/blob/master/config.yml

Thank you!