### PR TITLE
Fix xml+rss link header (#392)

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -109,7 +109,7 @@
 
 {{- /* RSS */}}
 {{ range .AlternativeOutputFormats -}}
-<link rel="{{ .Rel }}" type="{{ .MediaType.Type }}" href="{{ .Permalink | safeURL }}">
+<link rel="{{ .Rel }}" type="{{ .MediaType.Type | html }}" href="{{ .Permalink | safeURL }}">
 {{ end -}}
 {{- range .AllTranslations -}}
 <link rel="alternate" hreflang="{{ .Lang }}" href="{{ .Permalink }}" />


### PR DESCRIPTION
Fixes #392 by not encoding `rss+xml`.