### PR TITLE
Fix + in timezone in article:published_time and article:modified_time tags

### DIFF
--- a/layouts/partials/templates/opengraph.html
+++ b/layouts/partials/templates/opengraph.html
@@ -9,9 +9,9 @@
 <meta property="og:image" content="{{ (path.Join .RelPermalink .Params.cover.image ) | absURL }}" />
 {{- end}}
 {{- else }}
-
 {{- with $.Params.images -}}
-{{- range first 6 . }}<meta property="og:image" content="{{ . | absURL }}" />{{ end -}}
+{{- range first 6 . }}
+<meta property="og:image" content="{{ . | absURL }}" />{{ end -}}
 {{- else -}}
 {{- $images := $.Resources.ByType "image" -}}
 {{- $featured := $images.GetMatch "*feature*" -}}
@@ -19,21 +19,27 @@
 {{- with $featured -}}
 <meta property="og:image" content="{{ $featured.Permalink }}"/>
 {{- else -}}
-{{- with $.Site.Params.images }}<meta property="og:image" content="{{ index . 0 | absURL }}"/>{{ end -}}
+{{- with $.Site.Params.images }}
+<meta property="og:image" content="{{ index . 0 | absURL }}"/>
+{{ end -}}
 {{- end -}}
 {{- end -}}
 {{- end }}
-
 {{- if .IsPage }}
 {{- $iso8601 := "2006-01-02T15:04:05-07:00" -}}
 <meta property="article:section" content="{{ .Section }}" />
-{{ with .PublishDate }}<meta property="article:published_time" content="{{ .Format $iso8601 }}" />{{ end }}
-{{ with .Lastmod }}<meta property="article:modified_time" content="{{ .Format $iso8601 }}" />{{ end }}
+{{ with .PublishDate }}<meta property="article:published_time" content="{{ .Format $iso8601 | html }}" />{{ end }}
+{{ with .Lastmod }}<meta property="article:modified_time" content="{{ .Format $iso8601 | html }}" />{{ end }}
 {{- end -}}
-
-{{- with .Params.audio }}<meta property="og:audio" content="{{ . }}" />{{ end }}
-{{- with .Params.locale }}<meta property="og:locale" content="{{ . }}" />{{ end }}
-{{- with .Site.Params.title }}<meta property="og:site_name" content="{{ . }}" />{{ end }}
+{{- with .Params.audio }}
+<meta property="og:audio" content="{{ . }}" />
+{{ end }}
+{{- with .Params.locale }}
+<meta property="og:locale" content="{{ . }}" />
+{{ end }}
+{{- with .Site.Params.title }}
+<meta property="og:site_name" content="{{ . }}" />
+{{ end }}
 {{- with .Params.videos }}{{- range . }}
 <meta property="og:video" content="{{ . | absURL }}" />
 {{ end }}{{ end }}


### PR DESCRIPTION
I live in UTC+1:00, and noticed the same problem as with #393: The `+` gets html-encoded. So I applied the same fix here.

I also added some line breaks so that each tag is on its own line.