### PR TITLE
Add missing semicolons in CSS files

### DIFF
--- a/assets/css/common/404.css
+++ b/assets/css/common/404.css
@@ -7,5 +7,5 @@
     justify-content: center;
     height: 80%;
     font-size: 160px;
-    font-weight: 700
+    font-weight: 700;
 }

--- a/assets/css/common/archive.css
+++ b/assets/css/common/archive.css
@@ -1,44 +1,44 @@
 .archive-posts {
     width: 100%;
-    font-size: 16px
+    font-size: 16px;
 }
 
 .archive-year {
-    margin-top: 40px
+    margin-top: 40px;
 }
 
 .archive-year:not(:last-of-type) {
-    border-bottom: 2px solid var(--border)
+    border-bottom: 2px solid var(--border);
 }
 
 .archive-month {
     display: flex;
     align-items: flex-start;
-    padding: 10px 0
+    padding: 10px 0;
 }
 
 .archive-month-header {
     margin: 25px 0;
-    width: 200px
+    width: 200px;
 }
 
 .archive-month:not(:last-of-type) {
-    border-bottom: 1px solid var(--border)
+    border-bottom: 1px solid var(--border);
 }
 
 .archive-entry {
     position: relative;
     padding: 5px;
-    margin: 10px 0
+    margin: 10px 0;
 }
 
 .archive-entry-title {
     margin: 5px 0;
-    font-weight: 400
+    font-weight: 400;
 }
 
 .archive-count,
 .archive-meta {
     color: var(--secondary);
-    font-size: 14px
+    font-size: 14px;
 }

--- a/assets/css/common/footer.css
+++ b/assets/css/common/footer.css
@@ -1,7 +1,7 @@
 .footer,
 .top-link {
     font-size: 12px;
-    color: var(--secondary)
+    color: var(--secondary);
 }
 
 .footer {
@@ -9,12 +9,12 @@
     margin: auto;
     padding: calc((var(--footer-height) - var(--gap)) / 2) var(--gap);
     text-align: center;
-    line-height: 24px
+    line-height: 24px;
 }
 
 .footer span {
     margin-inline-start: 1px;
-    margin-inline-end: 1px
+    margin-inline-end: 1px;
 }
 
 .footer span:last-child {
@@ -23,11 +23,11 @@
 
 .footer a {
     color: inherit;
-    border-bottom: 1px solid var(--secondary)
+    border-bottom: 1px solid var(--secondary);
 }
 
 .footer a:hover {
-    border-bottom: 1px solid var(--primary)
+    border-bottom: 1px solid var(--primary);
 }
 
 .top-link {
@@ -41,7 +41,7 @@
     height: 42px;
     padding: 12px;
     border-radius: 64px;
-    transition: visibility .5s, opacity .8s linear
+    transition: visibility .5s, opacity .8s linear;
 }
 
 .top-link,
@@ -51,10 +51,10 @@
 
 .footer a:hover,
 .top-link:hover {
-    color: var(--primary)
+    color: var(--primary);
 }
 
 .top-link:focus,
 #theme-toggle:focus {
-    outline: 0
+    outline: 0;
 }

--- a/assets/css/common/header.css
+++ b/assets/css/common/header.css
@@ -5,11 +5,11 @@
     max-width: calc(var(--nav-width) + var(--gap) * 2);
     margin-inline-start: auto;
     margin-inline-end: auto;
-    line-height: var(--header-height)
+    line-height: var(--header-height);
 }
 
 .nav a {
-    display: block
+    display: block;
 }
 
 .logo,
@@ -19,7 +19,7 @@
 }
 
 .logo {
-    flex-wrap: inherit
+    flex-wrap: inherit;
 }
 
 .logo a {
@@ -33,7 +33,7 @@
     pointer-events: none;
     transform: translate(0, -10%);
     border-radius: 6px;
-    margin-inline-end: 8px
+    margin-inline-end: 8px;
 }
 
 #theme-toggle svg {
@@ -42,36 +42,36 @@
 
 button#theme-toggle  {
     font-size: 26px;
-    margin: auto 4px
+    margin: auto 4px;
 }
 
 body.dark #moon {
     vertical-align: middle;
-    display: none
+    display: none;
 }
 
 body:not(.dark) #sun {
-    display: none
+    display: none;
 }
 
 #menu {
     list-style: none;
     word-break: keep-all;
     overflow-x: auto;
-    white-space: nowrap
+    white-space: nowrap;
 }
 
 #menu li+li {
-    margin-inline-start: var(--gap)
+    margin-inline-start: var(--gap);
 }
 
 #menu a {
-    font-size: 16px
+    font-size: 16px;
 }
 
 #menu .active {
     font-weight: 500;
-    border-bottom: 2px solid currentColor
+    border-bottom: 2px solid currentColor;
 }
 
 .lang-switch li,
@@ -83,7 +83,7 @@ body:not(.dark) #sun {
 
 .lang-switch {
     display: flex;
-    flex-wrap: inherit
+    flex-wrap: inherit;
 }
 
 .lang-switch a {
@@ -93,5 +93,5 @@ body:not(.dark) #sun {
 }
 
 .logo-switches {
-    flex-wrap: inherit
+    flex-wrap: inherit;
 }

--- a/assets/css/common/main.css
+++ b/assets/css/common/main.css
@@ -3,15 +3,15 @@
     min-height: calc(100vh - var(--header-height) - var(--footer-height));
     max-width: calc(var(--main-width) + var(--gap) * 2);
     margin: auto;
-    padding: var(--gap)
+    padding: var(--gap);
 }
 
 .page-header h1 {
-    font-size: 40px
+    font-size: 40px;
 }
 
 .pagination {
-    display: flex
+    display: flex;
 }
 
 .pagination a {
@@ -20,24 +20,24 @@
     line-height: 36px;
     background: var(--primary);
     border-radius: calc(36px / 2);
-    padding: 0 16px
+    padding: 0 16px;
 }
 
 .pagination .next {
-    margin-inline-start: auto
+    margin-inline-start: auto;
 }
 
 .social-icons {
-    padding: 12px 0
+    padding: 12px 0;
 }
 
 .social-icons a:not(:last-of-type) {
-    margin-inline-end: 12px
+    margin-inline-end: 12px;
 }
 
 .social-icons a svg {
     height: 26px;
-    width: 26px
+    width: 26px;
 }
 
 code {

--- a/assets/css/common/post-entry.css
+++ b/assets/css/common/post-entry.css
@@ -4,33 +4,33 @@
     flex-direction: column;
     justify-content: center;
     min-height: 320px;
-    margin: var(--gap) 0 calc(var(--gap) * 2) 0
+    margin: var(--gap) 0 calc(var(--gap) * 2) 0;
 }
 
 .first-entry .entry-header {
     overflow: hidden;
     display: -webkit-box;
     -webkit-box-orient: vertical;
-    -webkit-line-clamp: 3
+    -webkit-line-clamp: 3;
 }
 
 .first-entry .entry-header h1 {
     font-size: 34px;
-    line-height: 1.3
+    line-height: 1.3;
 }
 
 .first-entry .entry-content {
     margin: 14px 0;
     font-size: 16px;
-    -webkit-line-clamp: 3
+    -webkit-line-clamp: 3;
 }
 
 .first-entry .entry-footer {
-    font-size: 14px
+    font-size: 14px;
 }
 
 .home-info .entry-content {
-    -webkit-line-clamp: unset
+    -webkit-line-clamp: unset;
 }
 
 .post-entry {
@@ -44,15 +44,15 @@
 }
 
 .post-entry:active {
-    transform: scale(.96)
+    transform: scale(.96);
 }
 
 .tag-entry .entry-cover {
-    display: none
+    display: none;
 }
 
 .entry-header h2 {
-    font-size: 24px
+    font-size: 24px;
 }
 
 .entry-content {
@@ -63,12 +63,12 @@
     overflow: hidden;
     display: -webkit-box;
     -webkit-box-orient: vertical;
-    -webkit-line-clamp: 2
+    -webkit-line-clamp: 2;
 }
 
 .entry-footer {
     color: var(--secondary);
-    font-size: 13px
+    font-size: 13px;
 }
 
 .entry-link {
@@ -76,31 +76,31 @@
     left: 0;
     right: 0;
     top: 0;
-    bottom: 0
+    bottom: 0;
 }
 
 .entry-cover,
 .entry-isdraft {
     font-size: 14px;
-    color: var(--secondary)
+    color: var(--secondary);
 }
 
 .entry-isdraft {
-    display: inline
+    display: inline;
 }
 
 .entry-cover {
     margin-bottom: var(--gap);
-    text-align: center
+    text-align: center;
 }
 
 .entry-cover img {
     border-radius: var(--radius);
     pointer-events: none;
-    width: 100%
+    width: 100%;
 }
 
 .entry-cover a {
     color: var(--secondary);
-    box-shadow: 0 1px 0 var(--primary)
+    box-shadow: 0 1px 0 var(--primary);
 }

--- a/assets/css/common/post-single.css
+++ b/assets/css/common/post-single.css
@@ -1,11 +1,11 @@
 .page-header,
 .post-header {
-    margin: 24px auto var(--content-gap) auto
+    margin: 24px auto var(--content-gap) auto;
 }
 
 .post-title {
     margin-bottom: 2px;
-    font-size: 40px
+    font-size: 40px;
 }
 
 .post-description {
@@ -18,14 +18,14 @@
     color: var(--secondary);
     font-size: 14px;
     display: flex;
-    flex-wrap: wrap
+    flex-wrap: wrap;
 }
 
 .post-meta .i18n_list li {
     display: inline-flex;
     list-style: none;
     margin: auto 3px;
-    box-shadow: 0 1px 0 var(--secondary)
+    box-shadow: 0 1px 0 var(--secondary);
 }
 
 .breadcrumbs a {
@@ -33,56 +33,56 @@
 }
 
 .post-content {
-    color: var(--content)
+    color: var(--content);
 }
 
 .post-content h3,
 .post-content h4,
 .post-content h5,
 .post-content h6 {
-    margin: 24px 0 16px
+    margin: 24px 0 16px;
 }
 
 .post-content h1 {
     margin: 40px auto 32px;
-    font-size: 40px
+    font-size: 40px;
 }
 
 .post-content h2 {
     margin: 32px auto 24px;
-    font-size: 32px
+    font-size: 32px;
 }
 
 .post-content h3 {
-    font-size: 24px
+    font-size: 24px;
 }
 
 .post-content h4 {
-    font-size: 16px
+    font-size: 16px;
 }
 
 .post-content h5 {
-    font-size: 14px
+    font-size: 14px;
 }
 
 .post-content h6 {
-    font-size: 12px
+    font-size: 12px;
 }
 
 .post-content a,
 .toc a:hover {
-    box-shadow: 0 1px 0
+    box-shadow: 0 1px 0;;
 }
 
 .post-content a code {
     margin: auto 0;
     border-radius: 0;
-    box-shadow: 0 -1px 0 var(--primary) inset
+    box-shadow: 0 -1px 0 var(--primary) inset;
 }
 
 .post-content del {
     text-decoration: none;
-    background: linear-gradient(to right, var(--primary) 100%, transparent 0) 0 50%/1px 1px repeat-x
+    background: linear-gradient(to right, var(--primary) 100%, transparent 0) 0 50%/1px 1px repeat-x;
 }
 
 .post-content dl,
@@ -90,46 +90,46 @@
 .post-content p,
 .post-content figure,
 .post-content ul {
-    margin-bottom: var(--content-gap)
+    margin-bottom: var(--content-gap);
 }
 
 .post-content ol,
 .post-content ul {
-    padding-inline-start: 20px
+    padding-inline-start: 20px;
 }
 
 .post-content li {
-    margin-top: 5px
+    margin-top: 5px;
 }
 
 .post-content li p {
-    margin-bottom: 0
+    margin-bottom: 0;
 }
 
 .post-content dl {
     display: flex;
     flex-wrap: wrap;
-    margin: 0
+    margin: 0;
 }
 
 .post-content dt {
     width: 25%;
-    font-weight: 700
+    font-weight: 700;
 }
 
 .post-content dd {
     width: 75%;
     margin-inline-start: 0;
-    padding-inline-start: 10px
+    padding-inline-start: 10px;
 }
 
 .post-content dd~dd,
 .post-content dt~dt {
-    margin-top: 10px
+    margin-top: 10px;
 }
 
 .post-content table {
-    margin-bottom: 32px
+    margin-bottom: 32px;
 }
 
 .post-content table th,
@@ -137,64 +137,64 @@
     min-width: 80px;
     padding: 12px 8px;
     line-height: 1.5;
-    border-bottom: 1px solid var(--border)
+    border-bottom: 1px solid var(--border);
 }
 
 .post-content table th {
     font-size: 14px;
-    text-align: start
+    text-align: start;
 }
 
 .post-content table:not(.highlighttable) td code:only-child {
-    margin: auto 0
+    margin: auto 0;
 }
 
 .post-content .highlight table {
-    border-radius: var(--radius)
+    border-radius: var(--radius);
 }
 
 .post-content .highlight:not(table),
 .post-content pre {
     margin: 10px auto;
     background: var(--hljs-bg) !important;
-    border-radius: var(--radius)
+    border-radius: var(--radius);
 }
 
 .post-content li>.highlight {
-    margin-inline-end: 0
+    margin-inline-end: 0;
 }
 
 .post-content ul pre {
-    margin-inline-start: calc(var(--gap) * -2)
+    margin-inline-start: calc(var(--gap) * -2);
 }
 
 .post-content .highlight pre {
-    margin: 0
+    margin: 0;
 }
 
 .post-content .highlighttable {
-    table-layout: fixed
+    table-layout: fixed;
 }
 
 .post-content .highlighttable td:first-child {
-    width: 40px
+    width: 40px;
 }
 
 .post-content .highlighttable td .linenodiv {
-    padding-inline-end: 0 !important
+    padding-inline-end: 0 !important;
 }
 
 .post-content .highlighttable td .highlight,
 .post-content .highlighttable td .linenodiv pre {
-    margin-bottom: 0
+    margin-bottom: 0;
 }
 
 .post-content .highlighttable td .highlight pre code::-webkit-scrollbar {
-    display: none
+    display: none;
 }
 
 .post-content .highlight span {
-    background: 0 0 !important
+    background: 0 0 !important;
 }
 
 .post-content code {
@@ -204,7 +204,7 @@
     font-size: .78em;
     line-height: 1.5;
     background: var(--code-bg);
-    border-radius: 2px
+    border-radius: 2px;
 }
 
 .post-content pre code {
@@ -221,7 +221,7 @@
 .post-content blockquote {
     margin: 20px 0;
     padding: 0 14px;
-    border-inline-start: 3px solid var(--primary)
+    border-inline-start: 3px solid var(--primary);
 }
 
 .post-content hr {
@@ -229,19 +229,19 @@
     height: 2px;
     background: var(--tertiary);
     border-top: 0;
-    border-bottom: 0
+    border-bottom: 0;
 }
 
 .post-content iframe {
-    max-width: 100%
+    max-width: 100%;
 }
 
 .post-content img {
-    border-radius: 4px
+    border-radius: 4px;
 }
 
 .post-content img[src*='#center'] {
-    margin: auto
+    margin: auto;
 }
 
 .post-content figure.align-center {
@@ -266,7 +266,7 @@
     border: 1px solid var(--border);
     background: var(--code-bg);
     border-radius: var(--radius);
-    padding: .4em
+    padding: .4em;
 }
 
 .dark .toc {
@@ -275,39 +275,39 @@
 
 .toc details summary {
     cursor: zoom-in;
-    margin-inline-start: 20px
+    margin-inline-start: 20px;
 }
 
 .toc details[open] summary {
-    cursor: zoom-out
+    cursor: zoom-out;
 }
 
 .toc .details {
     display: inline;
-    font-weight: 500
+    font-weight: 500;
 }
 
 .toc .inner {
     margin: 0 20px;
-    padding: 10px 20px
+    padding: 10px 20px;
 }
 
 .toc li ul {
-    margin-inline-start: var(--gap)
+    margin-inline-start: var(--gap);
 }
 
 .toc summary:focus {
-    outline: 0
+    outline: 0;
 }
 
 .post-footer {
-    margin-top: 56px
+    margin-top: 56px;
 }
 
 .post-tags li {
     display: inline-block;
     margin-inline-end: 3px;
-    margin-bottom: 5px
+    margin-bottom: 5px;
 }
 
 .post-tags a,
@@ -315,7 +315,7 @@
 .paginav {
     border-radius: var(--radius);
     background: var(--code-bg);
-    border: 1px solid var(--border)
+    border: 1px solid var(--border);
 }
 
 .post-tags a {
@@ -325,12 +325,12 @@
     color: var(--secondary);
     font-size: 14px;
     line-height: 34px;
-    background: var(--code-bg)
+    background: var(--code-bg);
 }
 
 .post-tags a:hover,
 .paginav a:hover {
-    background: var(--border)
+    background: var(--border);
 }
 
 .share-buttons {
@@ -338,26 +338,26 @@
     padding-inline-start: var(--radius);
     display: flex;
     justify-content: center;
-    overflow-x: auto
+    overflow-x: auto;
 }
 
 .share-buttons a {
-    margin-top: 10px
+    margin-top: 10px;
 }
 
 .share-buttons a:not(:last-of-type) {
-    margin-inline-end: 12px
+    margin-inline-end: 12px;
 }
 
 .share-buttons a svg {
     height: 30px;
     width: 30px;
     fill: currentColor;
-    transition: transform .1s
+    transition: transform .1s;
 }
 
 .share-buttons svg:active {
-    transform: scale(.96)
+    transform: scale(.96);
 }
 
 h1:hover .anchor,
@@ -369,25 +369,25 @@ h6:hover .anchor {
     display: inline-flex;
     color: var(--secondary);
     margin-inline-start: 8px;
-    font-weight: 500
+    font-weight: 500;
 }
 
 .post-content :not(table) ::-webkit-scrollbar-thumb {
     border: 2px solid var(--hljs-bg);
-    background: rgba(255, 255, 255, 0.32)
+    background: rgba(255, 255, 255, 0.32);
 }
 
 .post-content :not(table) ::-webkit-scrollbar-thumb:hover {
-    background: rgba(255, 255, 255, 0.56)
+    background: rgba(255, 255, 255, 0.56);
 }
 
 .gist table::-webkit-scrollbar-thumb {
     border: 2px solid rgb(255, 255, 255);
-    background: rgba(0, 0, 0, 0.32)
+    background: rgba(0, 0, 0, 0.32);
 }
 
 .gist table::-webkit-scrollbar-thumb:hover {
-    background: rgba(0, 0, 0, 0.56)
+    background: rgba(0, 0, 0, 0.56);
 }
 
 .post-content table::-webkit-scrollbar-thumb {

--- a/assets/css/common/profile-mode.css
+++ b/assets/css/common/profile-mode.css
@@ -1,7 +1,7 @@
 .buttons,
 .main .profile {
     display: flex;
-    justify-content: center
+    justify-content: center;
 }
 
 .main .profile {
@@ -10,23 +10,23 @@
     right: 0;
     align-items: center;
     height: 80%;
-    text-align: center
+    text-align: center;
 }
 
 .profile .profile_inner h1 {
-    padding: 12px 0
+    padding: 12px 0;
 }
 
 .profile img {
     display: inline-table;
     border-radius: 50%;
-    pointer-events: none
+    pointer-events: none;
 }
 
 .buttons {
     flex-wrap: wrap;
     max-width: 400px;
-    margin: 0 auto
+    margin: 0 auto;
 }
 
 .button {
@@ -34,13 +34,13 @@
     border-radius: var(--radius);
     margin: 8px;
     padding: 6px;
-    transition: transform .1s
+    transition: transform .1s;
 }
 
 .button-inner {
-    padding: 0 8px
+    padding: 0 8px;
 }
 
 .button:active {
-    transform: scale(.96)
+    transform: scale(.96);
 }

--- a/assets/css/common/search.css
+++ b/assets/css/common/search.css
@@ -41,5 +41,5 @@
 
 #searchResults .focus {
     transform: scale(.98);
-    border: 2px solid var(--tertiary)
+    border: 2px solid var(--tertiary);
 }

--- a/assets/css/common/terms.css
+++ b/assets/css/common/terms.css
@@ -1,7 +1,7 @@
 .terms-tags li {
     display: inline-block;
     margin: 10px;
-    font-weight: 500
+    font-weight: 500;
 }
 
 .terms-tags a {
@@ -9,10 +9,10 @@
     padding: 3px 10px;
     background: var(--tertiary);
     border-radius: 6px;
-    transition: transform .1s
+    transition: transform .1s;
 }
 
 .terms-tags a:active {
     background: var(--tertiary);
-    transform: scale(.96)
+    transform: scale(.96);
 }

--- a/assets/css/core/reset.css
+++ b/assets/css/core/reset.css
@@ -1,7 +1,7 @@
 *,
 ::after,
 ::before {
-    box-sizing: border-box
+    box-sizing: border-box;
 }
 
 html {
@@ -18,7 +18,7 @@ h3,
 h4,
 h5,
 h6 {
-    color: var(--primary)
+    color: var(--primary);
 }
 
 body {
@@ -26,7 +26,7 @@ body {
     font-size: 18px;
     line-height: 1.6;
     word-break: break-word;
-    background: var(--theme)
+    background: var(--theme);
 }
 
 article,
@@ -40,7 +40,7 @@ main,
 nav,
 section,
 table {
-    display: block
+    display: block;
 }
 
 h1,
@@ -49,7 +49,7 @@ h3,
 h4,
 h5,
 h6 {
-    line-height: 1.2
+    line-height: 1.2;
 }
 
 h1,
@@ -60,21 +60,21 @@ h5,
 h6,
 p {
     margin-top: 0;
-    margin-bottom: 0
+    margin-bottom: 0;
 }
 
 ul {
-    padding: 0
+    padding: 0;
 }
 
 a {
-    text-decoration: none
+    text-decoration: none;
 }
 
 body,
 figure,
 ul {
-    margin: 0
+    margin: 0;
 }
 
 table {
@@ -82,7 +82,7 @@ table {
     border-collapse: collapse;
     border-spacing: 0;
     overflow-x: auto;
-    word-break: keep-all
+    word-break: keep-all;
 }
 
 button,
@@ -96,43 +96,43 @@ textarea {
 
 input,
 textarea {
-    outline: 0
+    outline: 0;
 }
 
 button,
 input[type=button],
 input[type=submit] {
-    cursor: pointer
+    cursor: pointer;
 }
 
 input:-webkit-autofill,
 textarea:-webkit-autofill {
-    box-shadow: 0 0 0 50px var(--theme) inset
+    box-shadow: 0 0 0 50px var(--theme) inset;
 }
 
 img {
     display: block;
-    max-width: 100%
+    max-width: 100%;
 }
 
 ::-webkit-scrollbar-track {
-    background: 0 0
+    background: 0 0;
 }
 
 .list:not(.dark)::-webkit-scrollbar-track {
-    background: var(--code-bg)
+    background: var(--code-bg);
 }
 
 ::-webkit-scrollbar-thumb {
     background: var(--tertiary);
     border: 5px solid var(--theme);
-    border-radius: var(--radius)
+    border-radius: var(--radius);
 }
 
 .list:not(.dark)::-webkit-scrollbar-thumb {
-    border: 5px solid var(--code-bg)
+    border: 5px solid var(--code-bg);
 }
 
 ::-webkit-scrollbar-thumb:hover {
-    background: var(--secondary)
+    background: var(--secondary);
 }

--- a/assets/css/hljs/an-old-hope.min.css
+++ b/assets/css/hljs/an-old-hope.min.css
@@ -1,6 +1,6 @@
 .hljs-comment,
 .hljs-quote {
-    color: #b6b18b
+    color: #b6b18b;
 }
 
 .hljs-deletion,
@@ -11,7 +11,7 @@
 .hljs-tag,
 .hljs-template-variable,
 .hljs-variable {
-    color: #eb3c54
+    color: #eb3c54;
 }
 
 .hljs-built_in,
@@ -22,28 +22,28 @@
 .hljs-number,
 .hljs-params,
 .hljs-type {
-    color: #e7ce56
+    color: #e7ce56;
 }
 
 .hljs-attribute {
-    color: #ee7c2b
+    color: #ee7c2b;
 }
 
 .hljs-addition,
 .hljs-bullet,
 .hljs-string,
 .hljs-symbol {
-    color: #4fb4d7
+    color: #4fb4d7;
 }
 
 .hljs-section,
 .hljs-title {
-    color: #78bb65
+    color: #78bb65;
 }
 
 .hljs-keyword,
 .hljs-selector-tag {
-    color: #b45ea4
+    color: #b45ea4;
 }
 
 .hljs {
@@ -51,13 +51,13 @@
     overflow-x: auto;
     background: #1c1d21;
     color: #c0c5ce;
-    padding: .5em
+    padding: .5em;
 }
 
 .hljs-emphasis {
-    font-style: italic
+    font-style: italic;
 }
 
 .hljs-strong {
-    font-weight: 700
+    font-weight: 700;
 }


### PR DESCRIPTION
Many of the CSS files had no semicolon after the last rule in a block, which is proper syntax, but it's annoying when adding more rules. Since omitting the semicolons doesn't really have a benefit, I've decided to add them to ease editing the styles in the future.

(For example, they caused [this problem](https://github.com/adityatelange/hugo-PaperMod/pull/407#discussion_r628949132). Not a big deal, but still annoying and avoidable.)