### PR TITLE
Allow to search posts based on tags

### DIFF
--- a/layouts/_default/index.json
+++ b/layouts/_default/index.json
@@ -1,7 +1,7 @@
 {{- $.Scratch.Add "index" slice -}}
 {{- range .Site.RegularPages -}}
     {{- if and (not .Params.searchHidden) (ne .Layout `archives`) (ne .Layout `search`) }}
-    {{- $.Scratch.Add "index" (dict "title" .Title "content" .Plain "permalink" .Permalink "summary" .Summary) -}}
+    {{- $.Scratch.Add "index" (dict "title" .Title "content" .Plain "permalink" .Permalink "summary" .Summary "tags" .Params.Tags) -}}
     {{- end }}
 {{- end -}}
 {{- $.Scratch.Get "index" | jsonify -}}


### PR DESCRIPTION
Enable use of "tags" as keys/search pattern in search options.

Example Fuse configuration in config.yml:
```
fuseOpts:
        isCaseSensitive: false
        shouldSort: true
        location: 0
        distance: 1000
        threshold: 0.2
        minMatchCharLength: 2
        keys: ["title", "content", "summary",  "tags"]
```