### PR TITLE
fix post_meta/reading_time

### DIFF
--- a/layouts/partials/post_meta.html
+++ b/layouts/partials/post_meta.html
@@ -5,7 +5,7 @@
 {{- end }}
 
 {{- if (.Param "ShowReadingTime") -}}
-{{- $scratch.Add "meta" (slice (i18n "read_time" .ReadingTime | default (printf "%s min" .ReadingTime))) }}
+{{- $scratch.Add "meta" (slice (i18n "read_time" .ReadingTime | default (printf "%d min" .ReadingTime))) }}
 {{- end }}
 
 {{- with (partial "author.html" .) }}


### PR DESCRIPTION
The template is expecting a string to generate the formated output string but it's receiving a number type (probably int).

This PR fixes this simple problem that cause bugs like the one below.

![image](https://user-images.githubusercontent.com/15693688/120085103-bb585100-c0ab-11eb-9a10-7fe63460366c.png)
