### PR TITLE
Make the "PoweredBy" in the footer optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -4,11 +4,11 @@
     {{- else }}
     <span>&copy; {{ now.Year }} <a href="{{ "" | absLangURL }}">{{ .Site.Title }}</a></span>
     {{- end }}
-    <span>
+    <!-- <span>
         Powered by
         <a href="https://gohugo.io/" rel="noopener noreferrer" target="_blank">Hugo</a> &
         <a href="https://git.io/hugopapermod" rel="noopener" target="_blank">PaperMod</a>
-    </span>
+    </span> -->
 </footer>
 
 {{- if (not .Site.Params.disableScrollToTop) }}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -4,11 +4,13 @@
     {{- else }}
     <span>&copy; {{ now.Year }} <a href="{{ "" | absLangURL }}">{{ .Site.Title }}</a></span>
     {{- end }}
-    <!-- <span>
+    {{- if (not .Site.Params.disablePoweredBy) }}
+    <span>
         Powered by
         <a href="https://gohugo.io/" rel="noopener noreferrer" target="_blank">Hugo</a> &
         <a href="https://git.io/hugopapermod" rel="noopener" target="_blank">PaperMod</a>
-    </span> -->
+    </span>
+    {{- end }}
 </footer>
 
 {{- if (not .Site.Params.disableScrollToTop) }}


### PR DESCRIPTION
This change make the "PowerBy" section in the footer optional (control the visibility via params in the config file).

Not sure why there were no .gitignore file. I added one with just one entry for now to ignore the .DS_Store files (for MacOS)