### PR TITLE
Add ability to hide the header from the profile page

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -13,7 +13,9 @@
 {{- print " dark" }}
 {{- end -}}
 " id="top">
+    {{- if not .Site.Params.profileMode.ignoreHeader -}}
     {{- partialCached "header.html" . .Page -}}
+    {{- end }}
     <main class="main">
         {{- block "main" . }}{{ end }}
     </main>


### PR DESCRIPTION
Adds a new variable params.profileMode.hideHeader that can remove render.html from the profile page.

<!--

## READ BEFORE OPENING A PR

Thank you for contributing to hugo-PaperMod!
Please fill out the following questions to make it easier for us to review your
changes. You do not need to check all the boxes below.

**NOTE**: PaperMod does not have any external dependencies fetched from 3rd party
CDN servers. However we do have custom Head/Footer extender templates which you can use
to add those to your website.
https://github.com/adityatelange/hugo-PaperMod/wiki/FAQs#custom-head--footer

-->


**What does this PR change? What problem does it solve?**

This allows user to hide header from the profile page. In my case the title of the website and the title on the profile page are the same, so I decided just to hide . 

It might be a better a better idea to make it somehow a page property, so any page could hide the header, but I decided to start with the simplest solution.
<!--
Describe the changes and their purpose here, as detailed as and if  needed.

Please do not add 2 unrelated changes in a single PR as it is difficult to track/revert those in future.
-->


**Was the change discussed in an issue or in the Discussions before?**
No, I just went forward and made the change.
<!--
Link issues and relevant Discussions posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->


## PR Checklist

- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] This change adds a Social Icon which has a permissive license to use it.
- [x] This change **does not** any CDN resources/links.
- [x] This change **does not** include any unrelated scripts such as bash and python scripts.
- [ ] This change updates the overridden internal templates from HUGO's repository.
(I'm pretty sure it doesn't but I'm not certain.)