### PR TITLE
Remove extraneous space in toc.html

### DIFF
--- a/layouts/partials/toc.html
+++ b/layouts/partials/toc.html
@@ -68,7 +68,7 @@
                 {{- end -}}
                 {{- end }}
                 <li>
-                    <a href="#{{- $cleanedID  -}}" aria-label="{{- $header | plainify -}}">{{- $header | safeHTML -}}</a>
+                    <a href="#{{- $cleanedID -}}" aria-label="{{- $header | plainify -}}">{{- $header | safeHTML -}}</a>
                     {{- else }}
                 <li>
                     <a href="#{{- $cleanedID -}}" aria-label="{{- $header | plainify -}}">{{- $header | safeHTML -}}</a>


### PR DESCRIPTION
**What does this PR change? What problem does it solve?**

In some version of Hugo (e.g. the default one at Netlify) the extraneous space causes the following error:

```
8:12:29 PM: $ hugo
8:12:29 PM: Error: "/opt/build/repo/themes/PaperMod/layouts/partials/toc.html:71:1": parse failed: template: partials/toc.html:71: illegal number syntax: "-"
```

This PR removes the extraneous space.

**Was the change discussed in an issue or in the Discussions before?**

Yes, in https://github.com/adityatelange/hugo-PaperMod/issues/426 - there the solution was to update the version of Hugo.

However, this is a low risk change and it makes the onboarding more pleasant for new users as they do not need extra configuration. Also, the error message does not guide them towards a possible solution (i.e. setting the Hugo version).

**Test plan**

I tested with unmodified version and observed the error shown above. Then I tested the modified version and the error no longer appeared.

## PR Checklist

- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [X] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] This change adds a Social Icon which has a permissive license to use it.
- [X] This change **does not** include any CDN resources/links.
- [X] This change **does not** include any unrelated scripts such as bash and python scripts.
- [ ] This change updates the overridden internal templates from HUGO's repository.
