### PR TITLE
Fix profileMode imageUrl preloaded on every page

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -59,7 +59,7 @@
 {{- end }}
 
 {{- with .Site.Params.profileMode }}
-{{- if and .enabled .imageUrl }}
+{{- if and .enabled .imageUrl $.IsHome }}
 <link rel="preload" href="{{ .imageUrl }}" as="image">
 {{- end }}
 {{- end }}


### PR DESCRIPTION
Instead we now only preload on the home page.
Closes #494

**What does this PR change? What problem does it solve?**

Solves #494 by only preloading imageUrl on homepage.

**Was the change discussed in an issue or in the Discussions before?**
Created issue and PR about same time. Will update PR if needed, but for such a simple issue/fix it is unlikely (in #149 @adityatelange indicated that profileMode is only for homepage).

## PR Checklist

- [X] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [X] This change **does not** include any CDN resources/links.
- [X] This change **does not** include any unrelated scripts such as bash and python scripts.
