### PR TITLE
Improve auto meta description for better SEO

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -18,9 +18,31 @@
     {{- range $i, $e := .Params.keywords }}{{ if $i }}, {{ end }}{{ $e }}{{ end }} {{- else }}
     {{- range $i, $e := .Params.tags }}{{ if $i }}, {{ end }}{{ $e }}{{ end }} {{- end -}}" />
 {{- end }}
-<meta name="description" content="{{- with .Description }}{{ . }}{{- else }}{{- if .IsPage}}
-    {{- .Summary | default (printf "%s - %s" .Title  .Site.Title) }}{{- else }}
-    {{- with .Site.Params.description }}{{ . }}{{- end }}{{- end }}{{- end -}}">
+{{- $metaDescription := .Description -}}
+{{- if .IsHome -}}
+    {{- if isset site.Params "description" -}}
+        {{- $metaDescription = site.Params.description -}}
+    {{- end -}}
+{{- end -}}
+{{- if .Data.Terms -}}
+    {{- $metaDescription = printf "taxonomy (classification): list of %s" (partial "return-helpers/title" . | lower ) -}}
+{{- else if or .Data.Plural .Data.Singular -}}
+    {{- $metaDescription = printf "pages for taxonomy (classification) term: %s" (partial "return-helpers/title" . | lower ) -}}
+{{- end -}}
+{{- if lt (len $metaDescription) 15 -}}
+    {{- if isset .Params "description" -}}
+        {{- $metaDescription = .Params.description -}}
+    {{- else if isset .Params "summary" -}}
+        {{- $metaDescription = .Params.summary -}}
+    {{- else if gt (len .Summary) 15 -}}
+        {{- $metaDescription = .Summary -}}
+    {{- end -}}
+{{- end -}}
+{{- if lt (len $metaDescription) 15 -}}
+    {{- $metaDescription = (partial "return-helpers/title" (dict "curPage" . "concatSiteTitle" true)) | lower -}}
+{{- end -}}
+{{ $metaDescription = trim ($metaDescription | plainify | htmlUnescape) "\n\r " }}
+<meta name="description" content="{{- substr $metaDescription 0 159 -}}" />
 <meta name="author" content="{{ (partial "author.html" . ) }}">
 <link rel="canonical" href="{{ if .Params.canonicalURL -}} {{ trim .Params.canonicalURL " " }} {{- else -}} {{ .Permalink }} {{- end }}" />
 {{- if .Site.Params.analytics.google.SiteVerificationTag }}

--- a/layouts/partials/return-helpers/title.html
+++ b/layouts/partials/return-helpers/title.html
@@ -1,0 +1,35 @@
+{{- $ctx := . -}}
+{{- $concatSiteTitle := false -}}
+{{- if reflect.IsMap $ctx -}}
+    {{- if isset $ctx "concatSiteTitle" -}}
+        {{- if $ctx.concatSiteTitle -}}
+            {{- $concatSiteTitle = true -}}
+            {{- $ctx = $ctx.curPage -}}
+        {{- end -}}
+    {{- end -}}
+{{- end -}}
+{{- $foundTitle := "Untitled" -}}
+{{- $siteTitle := "Untitled Site" -}}
+{{- with $ctx -}}
+    {{- if .Site.Title }}
+        {{- $siteTitle = .Site.Title -}}
+    {{- end -}}
+    {{- if eq .Kind "home" -}}
+        {{- $concatSiteTitle = false -}}
+    {{- end -}}
+    {{- if .Title -}}
+        {{- $foundTitle = .Title -}}
+    {{- else if eq .Kind "home" -}}
+        {{- $foundTitle = $siteTitle -}}
+    {{- else if .File -}}
+        {{- if .File.TranslationBaseName -}}
+            {{ $foundTitle = .File.TranslationBaseName | humanize | title -}}
+        {{- end -}}
+    {{- end -}}
+{{- end -}}
+{{- if $concatSiteTitle -}}
+    {{- if or (lt (len $foundTitle) 15) (lt (add (len $foundTitle) (len $siteTitle)) 67) -}}
+      {{- $foundTitle = printf "%s | %s" $foundTitle $siteTitle -}}
+    {{- end -}}
+{{- end -}}
+{{- return $foundTitle -}}


### PR DESCRIPTION
**What does this PR change? What problem does it solve?**

According to Bing SEO scan meta description should be between 15 and 160
characters long. In addition, Bing complains if there is no meta
description. We therefore make a best effort at a useful description
meets these requirements, unless the user has explicity provided one.

**Was the change discussed in an issue or in the Discussions before?**

I am sending as a _draft_ PR as I think it would be awkward to paste this into a discussion or issue, and a purpose of draft PRs is discussion of a proposal that is known to need work.

I would like to hear thoughts on this proposal. If you'd prefer to have the discussion in Discussions but leave the PR for referring to the code that works too.

## PR Checklist

- [X ] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [X ] This change **does not** include any CDN resources/links.
