### PR TITLE
Add width and height attributes to cover images

### DIFF
--- a/assets/css/common/post-entry.css
+++ b/assets/css/common/post-entry.css
@@ -98,6 +98,7 @@
     border-radius: var(--radius);
     pointer-events: none;
     width: 100%;
+    height: auto;
 }
 
 .entry-cover a {

--- a/layouts/partials/cover.html
+++ b/layouts/partials/cover.html
@@ -19,8 +19,7 @@
             sizes="(min-width: 768px) 720px, 100vw" src="{{ $cover.Permalink }}" alt="{{ $alt }}" 
             width="{{ $cover.Width }}" height="{{ $cover.Height }}">
         {{- else }}{{/* Unprocessable image or responsive images disabled */}}
-        <img loading="lazy" src="{{ (path.Join .RelPermalink .Params.cover.image) | absURL }}" alt="{{ $alt }}" 
-            width="{{ $cover.Width }}" height="{{ $cover.Height }}">
+        <img loading="lazy" src="{{ (path.Join .RelPermalink .Params.cover.image) | absURL }}" alt="{{ $alt }}">
         {{- end }}
     {{- else }}{{/* For absolute urls and external links, no img processing here */}}
         {{- if $addLink }}<a href="{{ (.Params.cover.image) | absURL }}" target="_blank"

--- a/layouts/partials/cover.html
+++ b/layouts/partials/cover.html
@@ -23,7 +23,7 @@
             alt="{{ $alt }}"
             width="{{ $cover.Width }}"
             height="{{ $cover.Height }}"
-        />
+        >
         {{- else }}{{/* Unprocessable image or responsive images disabled */}}
         <img 
             loading="lazy"
@@ -31,12 +31,12 @@
             alt="{{ $alt }}"
             width="{{ $cover.Width }}"
             height="{{ $cover.Height }}"
-        />
+        >
         {{- end }}
     {{- else }}{{/* For absolute urls and external links, no img processing here */}}
         {{- if $addLink }}<a href="{{ (.Params.cover.image) | absURL }}" target="_blank"
             rel="noopener noreferrer">{{ end -}}
-            <img loading="lazy" src="{{ (.Params.cover.image) | absURL }}" alt="{{ $alt }}"/>
+            <img loading="lazy" src="{{ (.Params.cover.image) | absURL }}" alt="{{ $alt }}">
     {{- end }}
     {{- if $addLink }}</a>{{ end -}}
     {{/*  Display Caption  */}}

--- a/layouts/partials/cover.html
+++ b/layouts/partials/cover.html
@@ -16,9 +16,11 @@
                         {{ printf "%s %s" (($cover.Resize (printf "%sx" $size)).Permalink) (printf "%sw ," $size) -}}
                         {{ end }}
                     {{- end -}}{{$cover.Permalink }} {{printf "%dw" ($cover.Width)}}" 
-            sizes="(min-width: 768px) 720px, 100vw" src="{{ $cover.Permalink }}" alt="{{ $alt }}" width="{{ $cover.Width }}" height="{{ $cover.Height }}">
+            sizes="(min-width: 768px) 720px, 100vw" src="{{ $cover.Permalink }}" alt="{{ $alt }}" 
+            width="{{ $cover.Width }}" height="{{ $cover.Height }}">
         {{- else }}{{/* Unprocessable image or responsive images disabled */}}
-        <img loading="lazy" src="{{ (path.Join .RelPermalink .Params.cover.image) | absURL }}" alt="{{ $alt }}" width="{{ $cover.Width }}" height="{{ $cover.Height }}">
+        <img loading="lazy" src="{{ (path.Join .RelPermalink .Params.cover.image) | absURL }}" alt="{{ $alt }}" 
+            width="{{ $cover.Width }}" height="{{ $cover.Height }}">
         {{- end }}
     {{- else }}{{/* For absolute urls and external links, no img processing here */}}
         {{- if $addLink }}<a href="{{ (.Params.cover.image) | absURL }}" target="_blank"

--- a/layouts/partials/cover.html
+++ b/layouts/partials/cover.html
@@ -11,19 +11,32 @@
         {{- $processableFormats := (slice "jpg" "jpeg" "png" "tif" "bmp" "gif") }}
         {{- $prod := (hugo.IsProduction | or (eq .Site.Params.env "production")) }}
         {{- if (and (in $processableFormats $cover.MediaType.SubType) (ne .Site.Params.cover.responsiveImages false) (eq $prod true)) }}
-        <img loading="lazy" srcset="{{- range $size := $sizes -}}
-                        {{- if (ge $cover.Width $size) -}}
+        <img 
+            loading="lazy" 
+            srcset="{{- range $size := $sizes -}}
+                    {{- if (ge $cover.Width $size) -}}
                         {{ printf "%s %s" (($cover.Resize (printf "%sx" $size)).Permalink) (printf "%sw ," $size) -}}
-                        {{ end }}
-                    {{- end -}}{{$cover.Permalink }} {{printf "%dw" ($cover.Width)}}"
-            sizes="(min-width: 768px) 720px, 100vw" src="{{ $cover.Permalink }}" alt="{{ $alt }}" />
+                    {{ end }}
+                {{- end -}}{{$cover.Permalink }} {{printf "%dw" ($cover.Width)}}"
+            sizes="(min-width: 768px) 720px, 100vw"
+            src="{{ $cover.Permalink }}"
+            alt="{{ $alt }}"
+            width="{{ $cover.Width }}"
+            height="{{ $cover.Height }}"
+        />
         {{- else }}{{/* Unprocessable image or responsive images disabled */}}
-        <img loading="lazy" src="{{ (path.Join .RelPermalink .Params.cover.image) | absURL }}" alt="{{ $alt }}">
+        <img 
+            loading="lazy"
+            src="{{ (path.Join .RelPermalink .Params.cover.image) | absURL }}" 
+            alt="{{ $alt }}"
+            width="{{ $cover.Width }}"
+            height="{{ $cover.Height }}"
+        />
         {{- end }}
     {{- else }}{{/* For absolute urls and external links, no img processing here */}}
         {{- if $addLink }}<a href="{{ (.Params.cover.image) | absURL }}" target="_blank"
             rel="noopener noreferrer">{{ end -}}
-            <img loading="lazy" src="{{ (.Params.cover.image) | absURL }}" alt="{{ $alt }}">
+            <img loading="lazy" src="{{ (.Params.cover.image) | absURL }}" alt="{{ $alt }}"/>
     {{- end }}
     {{- if $addLink }}</a>{{ end -}}
     {{/*  Display Caption  */}}

--- a/layouts/partials/cover.html
+++ b/layouts/partials/cover.html
@@ -11,27 +11,14 @@
         {{- $processableFormats := (slice "jpg" "jpeg" "png" "tif" "bmp" "gif") }}
         {{- $prod := (hugo.IsProduction | or (eq .Site.Params.env "production")) }}
         {{- if (and (in $processableFormats $cover.MediaType.SubType) (ne .Site.Params.cover.responsiveImages false) (eq $prod true)) }}
-        <img 
-            loading="lazy" 
-            srcset="{{- range $size := $sizes -}}
-                    {{- if (ge $cover.Width $size) -}}
+        <img loading="lazy" srcset="{{- range $size := $sizes -}}
+                        {{- if (ge $cover.Width $size) -}}
                         {{ printf "%s %s" (($cover.Resize (printf "%sx" $size)).Permalink) (printf "%sw ," $size) -}}
-                    {{ end }}
-                {{- end -}}{{$cover.Permalink }} {{printf "%dw" ($cover.Width)}}"
-            sizes="(min-width: 768px) 720px, 100vw"
-            src="{{ $cover.Permalink }}"
-            alt="{{ $alt }}"
-            width="{{ $cover.Width }}"
-            height="{{ $cover.Height }}"
-        >
+                        {{ end }}
+                    {{- end -}}{{$cover.Permalink }} {{printf "%dw" ($cover.Width)}}" 
+            sizes="(min-width: 768px) 720px, 100vw" src="{{ $cover.Permalink }}" alt="{{ $alt }}" width="{{ $cover.Width }}" height="{{ $cover.Height }}">
         {{- else }}{{/* Unprocessable image or responsive images disabled */}}
-        <img 
-            loading="lazy"
-            src="{{ (path.Join .RelPermalink .Params.cover.image) | absURL }}" 
-            alt="{{ $alt }}"
-            width="{{ $cover.Width }}"
-            height="{{ $cover.Height }}"
-        >
+        <img loading="lazy" src="{{ (path.Join .RelPermalink .Params.cover.image) | absURL }}" alt="{{ $alt }}" width="{{ $cover.Width }}" height="{{ $cover.Height }}">
         {{- end }}
     {{- else }}{{/* For absolute urls and external links, no img processing here */}}
         {{- if $addLink }}<a href="{{ (.Params.cover.image) | absURL }}" target="_blank"


### PR DESCRIPTION
<!--

## READ BEFORE OPENING A PR

Thank you for contributing to hugo-PaperMod!
Please fill out the following questions to make it easier for us to review your
changes. You do not need to check all the boxes below.

**NOTE**: PaperMod does not have any external dependencies fetched from 3rd party
CDN servers. However we do have custom Head/Footer extender templates which you can use
to add those to your website.
https://github.com/adityatelange/hugo-PaperMod/wiki/FAQs#custom-head--footer

-->


**What does this PR change? What problem does it solve?**

When using cover images the layout shifts on initial load because the image dimensions can only be determined by the browser **after** loading the images.

I followed the recommendations from this [website](https://web.dev/optimize-cls/?utm_source=lighthouse&utm_medium=devtools#images-without-dimensions) linked to from Lighthouse in Chrome and added the width and height attributes to the cover images. From this the browser can determine the aspect ratio **before** loading any images.

Additionally, in the CSS file I have added the `height: auto` directive to the `.entry-cover img` selector. The height is then calculated based on the actual available width.

**Was the change discussed in an issue or in the Discussions before?**

Fix for #499 in the Discussions

## PR Checklist

- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] This change **does not** include any CDN resources/links.
- [x] This change **does not** include any unrelated scripts such as bash and python scripts.
