### PR TITLE
Add warning for bad meta description length (SEO)

### DIFF
--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -23,3 +23,12 @@
 
 - id: code_copied
   translation: "copied!"
+
+- id: seo_colon
+  translation: "SEO:"
+
+- id: meta_description_less_than_25
+  translation: "meta description is less than 25 characters long"
+
+- id: meta_description_greater_than_160
+  translation: "meta description is greater than 160 characters long"

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -18,9 +18,17 @@
     {{- range $i, $e := .Params.keywords }}{{ if $i }}, {{ end }}{{ $e }}{{ end }} {{- else }}
     {{- range $i, $e := .Params.tags }}{{ if $i }}, {{ end }}{{ $e }}{{ end }} {{- end -}}" />
 {{- end }}
-<meta name="description" content="{{- with .Description }}{{ . }}{{- else }}{{- if .IsPage}}
-    {{- .Summary | default (printf "%s - %s" .Title  .Site.Title) }}{{- else }}
-    {{- with .Site.Params.description }}{{ . }}{{- end }}{{- end }}{{- end -}}">
+{{- $description := "" -}}
+{{- with .Description }}{{ $description = . }}{{- else }}{{- if .IsPage}}
+    {{- $description = (.Summary | default (printf "%s - %s" .Title  .Site.Title)) }}{{- else }}
+    {{- with .Site.Params.description }}{{ $description = . }}{{- end }}{{- end }}{{- end -}}
+{{- if lt (len $description) 25 -}}
+    {{- warnf (print (T "seo_colon") " " .File.Path " " (T "meta_description_less_than_25")) -}}
+{{- end -}}
+{{- if gt (len $description) 160 -}}
+    {{- warnf (print (T "seo_colon") " " .File.Path " " (T "meta_description_greater_than_160")) -}}
+{{- end -}}
+<meta name="description" content="$description">
 <meta name="author" content="{{ (partial "author.html" . ) }}">
 <link rel="canonical" href="{{ if .Params.canonicalURL -}} {{ trim .Params.canonicalURL " " }} {{- else -}} {{ .Permalink }} {{- end }}" />
 {{- if .Site.Params.analytics.google.SiteVerificationTag }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -28,7 +28,7 @@
 {{- if gt (len $description) 160 -}}
     {{- warnf (print (T "seo_colon") " " .File.Path " " (T "meta_description_greater_than_160")) -}}
 {{- end -}}
-<meta name="description" content="$description">
+<meta name="description" content="{{ $description }}">
 <meta name="author" content="{{ (partial "author.html" . ) }}">
 <link rel="canonical" href="{{ if .Params.canonicalURL -}} {{ trim .Params.canonicalURL " " }} {{- else -}} {{ .Permalink }} {{- end }}" />
 {{- if .Site.Params.analytics.google.SiteVerificationTag }}


### PR DESCRIPTION
**What does this PR change? What problem does it solve?**

Warn on meta description <25 characters or >160 characters as this is
the range search engines prefer (according to Bing Webmaster Tools).

As I have added new strings I have made them translatable and provided the ``en`` translation. I haven't been able to figure out how to create a PR on the Wiki in order to provide an update to the list of translated strings there.

**Was the change discussed in an issue or in the Discussions before?**

No, but #521 discusses a draft PR #497 which was determined to not be appropriate as it missed translation glue for new strings and automated changing the description, which was deemed inappropriate as the blogger / site author should write a good description themselves.

It is still useful to know if one has this issue (especially when first switching to PaperMod) at build time, therefore I have added this warning in the event the (SEO) issue exists.

Finally, I wonder if you would like me to update the formatting of the description block, since it's no longer embedded inside the meta content attribute?

## PR Checklist

- [X] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [X] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [X] This change **does not** include any CDN resources/links.
- [X] This change **does not** include any unrelated scripts such as bash and python scripts.
