### PR TITLE
Never display the toc when it would be empty

### DIFF
--- a/layouts/partials/toc.html
+++ b/layouts/partials/toc.html
@@ -1,13 +1,13 @@
+{{- $headers := findRE "<h[1-6].*?>(.|\n])+?</h[1-6]>" .Content -}}
+{{- $has_headers := ge (len $headers) 1 -}}
+{{- if $has_headers -}}
 <div class="toc">
     <details {{if (.Param "TocOpen") }} open{{ end }}>
         <summary accesskey="c" title="(Alt + C)">
             <div class="details">{{- i18n "toc" | default "Table of Contents" }}</div>
         </summary>
-        <div class="inner">
-            {{- $headers := findRE "<h[1-6].*?>(.|\n])+?</h[1-6]>" .Content -}}
-            {{- $has_headers := ge (len $headers) 1 -}}
-            {{- if $has_headers -}}
 
+        <div class="inner">
             {{- $largest := 6 -}}
             {{- range $headers -}}
             {{- $headerLevel := index (findRE "[1-6]" . 1) 0 -}}
@@ -87,7 +87,7 @@
             {{- end -}}
             {{- end }}
             </ul>
-            {{- end }}
         </div>
     </details>
 </div>
+{{- end }}


### PR DESCRIPTION
IMO, there is no point inserting a table of content if the page has no titles
because in this case, the table of contents is empty.

<!--

## READ BEFORE OPENING A PR

Thank you for contributing to hugo-PaperMod!
Please fill out the following questions to make it easier for us to review your
changes. You do not need to check all the boxes below.

**NOTE**: PaperMod does not have any external dependencies fetched from 3rd party
CDN servers. However we do have custom Head/Footer extender templates which you can use
to add those to your website.
https://github.com/adityatelange/hugo-PaperMod/wiki/FAQs#custom-head--footer

-->


**What does this PR change? What problem does it solve?**
If TOC is enable on a page but the page has no titles, we end up with an empty TOC element, like so:
![image](https://user-images.githubusercontent.com/7347374/130335070-37f035fc-0d5d-40d1-9db1-9629dec1a8bf.png)
it make more sense in my opinion to avoid showing the table of content if it would be empty.
The alternative is that the user has to disable the TOC with the setting for each page that has no titles, a fairly manual and tedious process.
<!--
Describe the changes and their purpose here, as detailed as and if  needed.

Please do not add 2 unrelated changes in a single PR as it is difficult to track/revert those in future.
-->


**Was the change discussed in an issue or in the Discussions before?**
No
<!--
Link issues and relevant Discussions posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->


## PR Checklist

- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [X] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] This change adds a Social Icon which has a permissive license to use it.
- [X] This change **does not** include any CDN resources/links.
- [X] This change **does not** include any unrelated scripts such as bash and python scripts.
- [ ] This change updates the overridden internal templates from HUGO's repository.
