### PR TITLE
Add webp to processable formats

### DIFF
--- a/layouts/partials/cover.html
+++ b/layouts/partials/cover.html
@@ -8,7 +8,7 @@
         {{- if $addLink }}<a href="{{ (path.Join .RelPermalink .Params.cover.image) | absURL }}" target="_blank"
             rel="noopener noreferrer">{{ end -}}
         {{- $sizes := (slice "360" "480" "720" "1080" "1500") }}
-        {{- $processableFormats := (slice "jpg" "jpeg" "png" "tif" "bmp" "gif") }}
+        {{- $processableFormats := (slice "jpg" "jpeg" "png" "tif" "bmp" "gif" "webp") }}
         {{- $prod := (hugo.IsProduction | or (eq .Site.Params.env "production")) }}
         {{- if (and (in $processableFormats $cover.MediaType.SubType) (ne .Site.Params.cover.responsiveImages false) (eq $prod true)) }}
         <img loading="lazy" srcset="{{- range $size := $sizes -}}


### PR DESCRIPTION
**What does this PR change? What problem does it solve?**
It adds webp as cover image 'processable format' so that webp images can also be responsive.

**Was the change discussed in an issue or in the Discussions before?**
No.
## PR Checklist

- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [X] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] This change adds a Social Icon which has a permissive license to use it.
- [X] This change **does not** include any CDN resources/links.
- [X] This change **does not** include any unrelated scripts such as bash and python scripts.
- [ ] This change updates the overridden internal templates from HUGO's repository.
