### PR TITLE
Allow page-based overriding of copy code buttons

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -82,7 +82,7 @@
 </script>
 {{- end }}
 
-{{- if (and (eq .Kind "page") (ne .Layout "archives") (ne .Layout "search") (.Site.Params.ShowCodeCopyButtons)) }}
+{{- if (and (eq .Kind "page") (ne .Layout "archives") (ne .Layout "search") (.Param "showCodeCopyButtons")) }}
 <script>
     document.querySelectorAll('pre > code').forEach((codeblock) => {
         const container = codeblock.parentNode.parentNode;


### PR DESCRIPTION
Allows specifying "showCodeCopyButtons: true/false" in the front matter
of a page. If it is not specified, the value from the site-wide
configuration is used.

**What does this PR change? What problem does it solve?**

It allows enabling/disabling code copy buttons for a specific page while keeping the default value for the rest of the site.

## PR Checklist

- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] This change adds a Social Icon which has a permissive license to use it.
- [x] This change **does not** include any CDN resources/links.
- [x] This change **does not** include any unrelated scripts such as bash and python scripts.
- [ ] This change updates the overridden internal templates from HUGO's repository.
