### PR TITLE
Fix button not allowed inside anchor in footer

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -15,11 +15,11 @@
 
 {{- if (not .Site.Params.disableScrollToTop) }}
 <a href="#top" aria-label="go to top" title="Go to Top (Alt + G)">
-    <button class="top-link" id="top-link" type="button" accesskey="g">
+    <span class="top-link" id="top-link" accesskey="g" aria-hidden="true">
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 12 6" fill="currentColor">
             <path d="M12 6H0l6-6z" />
         </svg>
-    </button>
+    </span>
 </a>
 {{- end }}
 

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -14,12 +14,10 @@
 {{- end }}
 
 {{- if (not .Site.Params.disableScrollToTop) }}
-<a href="#top" aria-label="go to top" title="Go to Top (Alt + G)">
-    <span class="top-link" id="top-link" accesskey="g" aria-hidden="true">
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 12 6" fill="currentColor">
-            <path d="M12 6H0l6-6z" />
-        </svg>
-    </span>
+<a href="#top" aria-label="go to top" title="Go to Top (Alt + G)" class="top-link" id="top-link" accesskey="g">
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 12 6" fill="currentColor">
+        <path d="M12 6H0l6-6z" />
+    </svg>
 </a>
 {{- end }}
 


### PR DESCRIPTION
**What does this PR change? What problem does it solve?**

HTML validators complain (correctly) about the footer "top-link" which has a \<button> inside an anchor (\<a>) element.

As per [Mozilla Developer Network page for \<a> element allowed properties](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#properties) 'interactive elements' (including \<button>) are not allowed inside an anchor element (\<a>).

I replace the ``<button>`` with a ``<span>`` and add an ``aria-hidden="true"`` to avoid screen readers repeating ``go to top``, which is already present as an ``aria-title`` on the anchor element.

**Was the change discussed in an issue or in the Discussions before?**

Closes #549

It is currently in action on <https://www.princesandmadmen.ca>.

## PR Checklist

- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [X] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [X] I have verified that the code works as described/as intended.
- [ ] This change adds a Social Icon which has a permissive license to use it.
- [X] This change **does not** include any CDN resources/links.
- [X] This change **does not** include any unrelated scripts such as bash and python scripts.
- [ ] This change updates the overridden internal templates from HUGO's repository.
