### PR TITLE
Fix div not allowed in summary element in ToC

### DIFF
--- a/layouts/partials/toc.html
+++ b/layouts/partials/toc.html
@@ -4,7 +4,7 @@
 <div class="toc">
     <details {{if (.Param "TocOpen") }} open{{ end }}>
         <summary accesskey="c" title="(Alt + C)">
-            <div class="details">{{- i18n "toc" | default "Table of Contents" }}</div>
+            <span class="details">{{- i18n "toc" | default "Table of Contents" }}</span>
         </summary>
 
         <div class="inner">


### PR DESCRIPTION
**What does this PR change? What problem does it solve?**

As per [Mozilla Developer Network detail summary element page](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/summary) only 'phrasing elements' and/or one element of heading content are allowed inside a \<summary> element.

Once again found by (valid) html validator complaint (I turn off the parts that are about opinions vs. HTML standards).

The table of contents \<summary> currently contains a \<div>.

I have replaced the \<div> with a \<span> and it appears to work on <https://www.princesandmadmen.ca/post/schizophrenia-talk/> although increasing the font-size might be desirable.

**Was the change discussed in an issue or in the Discussions before?**

Closes #550 

## PR Checklist

- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [X] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [X] I have verified that the code works as described/as intended.
- [ ] This change adds a Social Icon which has a permissive license to use it.
- [X] This change **does not** include any CDN resources/links.
- [X] This change **does not** include any unrelated scripts such as bash and python scripts.
- [ ] This change updates the overridden internal templates from HUGO's repository.
