### PR TITLE
Fix schema_json when baseURL omits trailing slash

### DIFF
--- a/layouts/partials/templates/schema_json.html
+++ b/layouts/partials/templates/schema_json.html
@@ -18,7 +18,11 @@
 </script>
 {{- else if (or .IsPage .IsSection) }}
 {{/* BreadcrumbList */}}
-{{- $url := replace .Parent.Permalink ( printf "%s" .Site.BaseURL) "" }}
+{{- $base_url := urls.Parse .Site.BaseURL -}}
+{{- if eq $base_url.Path "" -}}
+{{- $base_url = urls.Parse (printf "%s/" .Site.BaseURL) -}}
+{{- end -}}
+{{- $url := replace .Parent.Permalink ( printf "%s" ($base_url | string)) "" }}
 {{- $lang_url := strings.TrimPrefix ( printf "%s/" .Lang) $url }}
 {{- $bc_list := (split $lang_url "/")}}
 


### PR DESCRIPTION
**What does this PR change? What problem does it solve?**

Google Search Console warns of syntax errors in structured data (the
breadcrumb trail) when breadcrumbs are enable and the .Site.BaseURL
is configured without a trailing slash (/).

This commit fixes the schema_json partial by temporarily adding the
omitted slash (/) so that the breadcrumb splitting works as expected.

**Was the change discussed in an issue or in the Discussions before?**

Closes #558 

## PR Checklist

- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [X] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [X] I have verified that the code works as described/as intended.
- [ ] This change adds a Social Icon which has a permissive license to use it.
- [X] This change **does not** include any CDN resources/links.
- [X] This change **does not** include any unrelated scripts such as bash and python scripts.
- [ ] This change updates the overridden internal templates from HUGO's repository.

Not sure on the last task: I don't see a ``schema_json`` in Hugo repo, but I do see a ``schema``.