### PR TITLE
Rgba to rgb

### DIFF
--- a/assets/css/common/post-single.css
+++ b/assets/css/common/post-single.css
@@ -210,7 +210,7 @@
     display: block;
     margin: auto 0;
     padding: 10px;
-    color: rgba(255, 255, 255, 0.8);
+    color: rgb(213, 213, 214);
     background: 0 0;
     border-radius: 0;
     overflow-x: auto;

--- a/assets/css/common/post-single.css
+++ b/assets/css/common/post-single.css
@@ -374,20 +374,20 @@ h6:hover .anchor {
 
 .post-content :not(table) ::-webkit-scrollbar-thumb {
     border: 2px solid var(--hljs-bg);
-    background: rgba(255, 255, 255, 0.32);
+    background: rgb(113, 113, 117);
 }
 
 .post-content :not(table) ::-webkit-scrollbar-thumb:hover {
-    background: rgba(255, 255, 255, 0.56);
+    background: rgb(163, 163, 165);
 }
 
 .gist table::-webkit-scrollbar-thumb {
     border: 2px solid rgb(255, 255, 255);
-    background: rgba(0, 0, 0, 0.32);
+    background: rgb(173, 173, 173);
 }
 
 .gist table::-webkit-scrollbar-thumb:hover {
-    background: rgba(0, 0, 0, 0.56);
+    background: rgb(112, 112, 112);
 }
 
 .post-content table::-webkit-scrollbar-thumb {

--- a/assets/css/core/theme-vars.css
+++ b/assets/css/core/theme-vars.css
@@ -6,27 +6,27 @@
     --header-height: 60px;
     --footer-height: 60px;
     --radius: 8px;
-    --theme: rgb(255 255 255);
-    --entry: rgb(255 255 255);
+    --theme: rgb(255, 255, 255);
+    --entry: rgb(255, 255, 255);
     --primary: rgb(30, 30, 30);
     --secondary: rgb(108, 108, 108);
     --tertiary: rgb(214, 214, 214);
     --content: rgb(31, 31, 31);
-    --hljs-bg: rgb(28 29 33);
-    --code-bg: rgb(245 245 245);
-    --border: rgb(238 238 238);
+    --hljs-bg: rgb(28, 29, 33);
+    --code-bg: rgb(245, 245, 245);
+    --border: rgb(238, 238, 238);
 }
 
 .dark {
-    --theme: rgb(29 30 32);
-    --entry: rgb(46 46 51);
+    --theme: rgb(29, 30, 32);
+    --entry: rgb(46, 46, 51);
     --primary: rgb(218, 218, 219);
     --secondary: rgb(155, 156, 157);
     --tertiary: rgb(65, 66, 68);
     --content: rgb(196, 196, 197);
-    --hljs-bg: rgb(46 46 51);
-    --code-bg: rgb(55 56 62);
-    --border: rgb(51 51 51);
+    --hljs-bg: rgb(46, 46, 51);
+    --code-bg: rgb(55, 56, 62);
+    --border: rgb(51, 51, 51);
 }
 
 .list {

--- a/assets/css/core/theme-vars.css
+++ b/assets/css/core/theme-vars.css
@@ -18,15 +18,15 @@
 }
 
 .dark {
-    --theme: #1d1e20;
-    --entry: #2e2e33;
+    --theme: rgb(29 30 32);
+    --entry: rgb(46 46 51);
     --primary: rgb(218, 218, 219);
     --secondary: rgb(155, 156, 157);
     --tertiary: rgb(65, 66, 68);
     --content: rgb(196, 196, 197);
-    --hljs-bg: #2e2e33;
-    --code-bg: #37383e;
-    --border: #333;
+    --hljs-bg: rgb(46 46 51);
+    --code-bg: rgb(55 56 62);
+    --border: rgb(51 51 51);
 }
 
 .list {

--- a/assets/css/core/theme-vars.css
+++ b/assets/css/core/theme-vars.css
@@ -20,10 +20,10 @@
 .dark {
     --theme: #1d1e20;
     --entry: #2e2e33;
-    --primary: rgba(255, 255, 255, 0.84);
-    --secondary: rgba(255, 255, 255, 0.56);
-    --tertiary: rgba(255, 255, 255, 0.16);
-    --content: rgba(255, 255, 255, 0.74);
+    --primary: rgb(218, 218, 219);
+    --secondary: rgb(155, 156, 157);
+    --tertiary: rgb(65, 66, 68);
+    --content: rgb(196, 196, 197);
     --hljs-bg: #2e2e33;
     --code-bg: #37383e;
     --border: #333;

--- a/assets/css/core/theme-vars.css
+++ b/assets/css/core/theme-vars.css
@@ -8,10 +8,10 @@
     --radius: 8px;
     --theme: #fff;
     --entry: #fff;
-    --primary: rgba(0, 0, 0, 0.88);
-    --secondary: rgba(0, 0, 0, 0.56);
-    --tertiary: rgba(0, 0, 0, 0.16);
-    --content: rgba(0, 0, 0, 0.88);
+    --primary: rgb(30, 30, 30);
+    --secondary: rgb(108, 108, 108);
+    --tertiary: rgb(214, 214, 214);
+    --content: rgb(31, 31, 31);
     --hljs-bg: #1c1d21;
     --code-bg: #f5f5f5;
     --border: #eee;

--- a/assets/css/core/theme-vars.css
+++ b/assets/css/core/theme-vars.css
@@ -6,15 +6,15 @@
     --header-height: 60px;
     --footer-height: 60px;
     --radius: 8px;
-    --theme: #fff;
-    --entry: #fff;
+    --theme: rgb(255 255 255);
+    --entry: rgb(255 255 255);
     --primary: rgb(30, 30, 30);
     --secondary: rgb(108, 108, 108);
     --tertiary: rgb(214, 214, 214);
     --content: rgb(31, 31, 31);
-    --hljs-bg: #1c1d21;
-    --code-bg: #f5f5f5;
-    --border: #eee;
+    --hljs-bg: rgb(28 29 33);
+    --code-bg: rgb(245 245 245);
+    --border: rgb(238 238 238);
 }
 
 .dark {

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -113,7 +113,48 @@
 {{ end -}}
 {{- range .AllTranslations -}}
 <link rel="alternate" hreflang="{{ .Lang }}" href="{{ .Permalink }}" />
-{{ end }}
+{{ end -}}
+
+<noscript>
+    <style>
+        #theme-toggle,
+        .top-link {
+            display: none;
+        }
+
+    </style>
+    {{- if (and (ne .Site.Params.defaultTheme "light") (ne .Site.Params.defaultTheme "dark")) }}
+    <style>
+        @media (prefers-color-scheme: dark) {
+            :root {
+                --theme: #1d1e20;
+                --entry: #2e2e33;
+                --primary: rgba(255, 255, 255, 0.84);
+                --secondary: rgba(255, 255, 255, 0.56);
+                --tertiary: rgba(255, 255, 255, 0.16);
+                --content: rgba(255, 255, 255, 0.74);
+                --hljs-bg: #2e2e33;
+                --code-bg: #37383e;
+                --border: #333;
+            }
+
+            .list {
+                background: var(--theme);
+            }
+
+            .list:not(.dark)::-webkit-scrollbar-track {
+                background: 0 0;
+            }
+
+            .list:not(.dark)::-webkit-scrollbar-thumb {
+                border-color: var(--theme);
+            }
+        }
+
+    </style>
+    {{- end }}
+</noscript>
+
 {{- partial "extend_head.html" . -}}
 
 {{- /* Misc */}}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -127,15 +127,15 @@
     <style>
         @media (prefers-color-scheme: dark) {
             :root {
-                --theme: #1d1e20;
-                --entry: #2e2e33;
-                --primary: rgba(255, 255, 255, 0.84);
-                --secondary: rgba(255, 255, 255, 0.56);
-                --tertiary: rgba(255, 255, 255, 0.16);
-                --content: rgba(255, 255, 255, 0.74);
-                --hljs-bg: #2e2e33;
-                --code-bg: #37383e;
-                --border: #333;
+                --theme: rgb(29, 30, 32);
+                --entry: rgb(46, 46, 51);
+                --primary: rgb(218, 218, 219);
+                --secondary: rgb(155, 156, 157);
+                --tertiary: rgb(65, 66, 68);
+                --content: rgb(196, 196, 197);
+                --hljs-bg: rgb(46, 46, 51);
+                --code-bg: rgb(55, 56, 62);
+                --border: rgb(51, 51, 51);
             }
 
             .list {

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -38,45 +38,6 @@
 
 </script>
 {{- end }}
-<noscript>
-    <style type="text/css">
-        #theme-toggle,
-        .top-link {
-            display: none;
-        }
-
-    </style>
-    {{- if (and (ne .Site.Params.defaultTheme "light") (ne .Site.Params.defaultTheme "dark")) }}
-    <style>
-        @media (prefers-color-scheme: dark) {
-            :root {
-                --theme: #1d1e20;
-                --entry: #2e2e33;
-                --primary: rgba(255, 255, 255, 0.84);
-                --secondary: rgba(255, 255, 255, 0.56);
-                --tertiary: rgba(255, 255, 255, 0.16);
-                --content: rgba(255, 255, 255, 0.74);
-                --hljs-bg: #2e2e33;
-                --code-bg: #37383e;
-                --border: #333;
-            }
-
-            .list {
-                background: var(--theme);
-            }
-
-            .list:not(.dark)::-webkit-scrollbar-track {
-                background: 0 0;
-            }
-
-            .list:not(.dark)::-webkit-scrollbar-thumb {
-                border-color: var(--theme);
-            }
-        }
-
-    </style>
-    {{- end }}
-</noscript>
 
 <header class="header">
     <nav class="nav">

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -50,15 +50,15 @@
     <style>
         @media (prefers-color-scheme: dark) {
             :root {
-                --theme: rgb(29, 30, 32);
-                --entry: rgb(46, 46, 51);
-                --primary: rgb(218, 218, 219);
-                --secondary: rgb(155, 156, 157);
-                --tertiary: rgb(65, 66, 68);
-                --content: rgb(196, 196, 197);
-                --hljs-bg: rgb(46, 46, 51);
-                --code-bg: rgb(55, 56, 62);
-                --border: rgb(51, 51, 51);
+                --theme: #1d1e20;
+                --entry: #2e2e33;
+                --primary: rgba(255, 255, 255, 0.84);
+                --secondary: rgba(255, 255, 255, 0.56);
+                --tertiary: rgba(255, 255, 255, 0.16);
+                --content: rgba(255, 255, 255, 0.74);
+                --hljs-bg: #2e2e33;
+                --code-bg: #37383e;
+                --border: #333;
             }
 
             .list {

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -50,15 +50,15 @@
     <style>
         @media (prefers-color-scheme: dark) {
             :root {
-                --theme: #1d1e20;
-                --entry: #2e2e33;
-                --primary: rgba(255, 255, 255, 0.84);
-                --secondary: rgba(255, 255, 255, 0.56);
-                --tertiary: rgba(255, 255, 255, 0.16);
-                --content: rgba(255, 255, 255, 0.74);
-                --hljs-bg: #2e2e33;
-                --code-bg: #37383e;
-                --border: #333;
+                --theme: rgb(29, 30, 32);
+                --entry: rgb(46, 46, 51);
+                --primary: rgb(218, 218, 219);
+                --secondary: rgb(155, 156, 157);
+                --tertiary: rgb(65, 66, 68);
+                --content: rgb(196, 196, 197);
+                --hljs-bg: rgb(46, 46, 51);
+                --code-bg: rgb(55, 56, 62);
+                --border: rgb(51, 51, 51);
             }
 
             .list {


### PR DESCRIPTION
<!--

## READ BEFORE OPENING A PR

Thank you for contributing to hugo-PaperMod!
Please fill out the following questions to make it easier for us to review your
changes. You do not need to check all the boxes below.

**NOTE**: PaperMod does not have any external dependencies fetched from 3rd party
CDN servers. However we do have custom Head/Footer extender templates which you can use
to add those to your website.
https://github.com/adityatelange/hugo-PaperMod/wiki/FAQs#custom-head--footer

-->


**What does this PR change? What problem does it solve?**

<!--
Describe the changes and their purpose here, as detailed as and if  needed.

Please do not add 2 unrelated changes in a single PR as it is difficult to track/revert those in future.
-->

Because the theme's colors are set using opacity instead of actual color values, they interfere with elements other than text. For example, dark elements styled by entry-content use the --secondary color of rgba(255, 255, 255, 0.56). The text reads fine as a grey color against the black background, but if you add an emoji into your content it will also take on the 0.56 opacity value and look like it's fading away.

This PR includes: Same color, but no opacity issues.

The opacity of `go to top` button also changes here

**Was the change discussed in an issue or in the Discussions before?**

<!--
Link issues and relevant Discussions posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

[BUG] Emojis affected by theme opacity values Fixes: #557


## PR Checklist

- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [ ] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have verified that the code works as described/as intended.
- [ ] This change adds a Social Icon which has a permissive license to use it.
- [ ] This change **does not** include any CDN resources/links.
- [ ] This change **does not** include any unrelated scripts such as bash and python scripts.
- [ ] This change updates the overridden internal templates from HUGO's repository.
