### PR TITLE
Fix code line highlighting

### DIFF
--- a/assets/css/common/post-single.css
+++ b/assets/css/common/post-single.css
@@ -193,10 +193,6 @@
     display: none;
 }
 
-.post-content .highlight span {
-    background: 0 0 !important;
-}
-
 .post-content code {
     margin: auto 4px;
     padding: 4px 6px;


### PR DESCRIPTION
**What does this PR change? What problem does it solve?**

Fix code line highlighting by deleting a CSS rule.

Verified this works locally and looks good (see the images in the related discussion).

**Was the change discussed in an issue or in the Discussions before?**

https://github.com/adityatelange/hugo-PaperMod/discussions/525

## PR Checklist

- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have verified that the code works as described/as intended.
- [ ] This change adds a Social Icon which has a permissive license to use it.
- [x] This change **does not** include any CDN resources/links.
- [x] This change **does not** include any unrelated scripts such as bash and python scripts.
- [ ] This change updates the overridden internal templates from HUGO's repository.
