### PR TITLE
Set theme-color in meta-tag to --primary (used by Safari 15)

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -38,6 +38,10 @@
 
 </script>
 {{- end }}
+<script>
+  var themeColor = getComputedStyle(document.body).getPropertyValue('--primary');
+  document.querySelector('meta[name="theme-color"]').setAttribute('content', themeColor)
+</script>
 
 <header class="header">
     <nav class="nav">


### PR DESCRIPTION
Safari 15 has introduced support for the `theme-color` meta-tag, which defines the color of the tab-bar: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta/name/theme-color
(Chrome on Android also has it, Chrome and Edge use it for PWAs).

Currently, the theme is hard-coded to one color, `#2e2e33`:

https://github.com/adityatelange/hugo-PaperMod/blob/7c930ee4ea1b27ebdcb72ccb4c71656ecbde92b7/layouts/partials/head.html#L104

I would much prefer a color from the site's theme to be used.

## Question 1: How?

Unfortunately, `<meta name="theme-color" content="var(--theme)">` is not supported (see https://css-tricks.com/meta-theme-color-and-trickery/#custom-properties). So the next best thing (that _I_ could come up with) is to run a script that reads the variable and sets the tag:

```
  var themeColor = getComputedStyle(document.body).getPropertyValue('--primary');
  document.querySelector('meta[name="theme-color"]').setAttribute('content', themeColor)
```

(Note: I am _not_ a js dev, I have no idea what I'm doing, there's a good chance that there's a more clever version of this. But this one works 😉)

This script has to be run _after_ the `<head>` tag is closed.

## Question 2: Which color?

The first, obvious choice, was `--theme`. However, that lack of contrast is really not beautiful:

<img width="1245" alt="image" src="https://user-images.githubusercontent.com/7119122/135717080-5d13cd5a-17fd-43f5-ba62-5ce3dc2188fa.png">

At least in _my_ usage of the theme, `--primary` would be the "proper" contrasting color:

<img width="1245" alt="image" src="https://user-images.githubusercontent.com/7119122/135717101-0e7ddaf0-c17d-4857-83aa-1ddeaed48807.png">

It might also make sense to somehow let the user of the theme decide that, with a customer variable somewhere. That's up to you to decide 😉 

## PR Checklist

- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [ ] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have verified that the code works as described/as intended.
- [ ] This change adds a Social Icon which has a permissive license to use it.
- [ ] This change **does not** include any CDN resources/links.
- [ ] This change **does not** include any unrelated scripts such as bash and python scripts.
- [ ] This change updates the overridden internal templates from HUGO's repository.
