### PR TITLE
Added missing comma in json

### DIFF
--- a/layouts/partials/templates/schema_json.html
+++ b/layouts/partials/templates/schema_json.html
@@ -40,7 +40,7 @@
       "position": {{ add 1 $index  }},
       "name": {{ $bc_pg.Name }},
       "item": {{ $bc_pg.Permalink | safeHTML }}
-    }
+    },
     {{- end }}
 
   {{- end }}


### PR DESCRIPTION

**What does this PR change? What problem does it solve?**
When running a basic `hugo` build the build fails with a JSON parsing error
```
☁  aaronheld-blog [papermod] ⚡  hugo
Start building sites … 
hugo v0.84.0+extended linux/amd64 BuildDate=unknown
ERROR 2021/10/30 10:46:04 JSON parse error: expected comma character or an array or object ending on line 111 and column 40
   12:     {
           ^
```

also a stackoverflow question: https://stackoverflow.com/questions/68088702/json-parse-error-on-running-hugo-command

**The change**
this PR just adds a comma in a rendered JSON block for `<script type="application/ld+json">` in the `schema-json.html`template.
That item is an array, so it works with zero or 1 listItem, but with more then 1 you need a comma for valid JSON

## PR Checklist

- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [ ] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have verified that the code works as described/as intended.
- [ ] This change adds a Social Icon which has a permissive license to use it.
- [x] This change **does not** include any CDN resources/links.
- [x] This change **does not** include any unrelated scripts such as bash and python scripts.
- [ ] This change updates the overridden internal templates from HUGO's repository.
