### PR TITLE
Adding 'Phone' to Socials

### DIFF
--- a/layouts/partials/social_icons.html
+++ b/layouts/partials/social_icons.html
@@ -1,7 +1,13 @@
 <div class="social-icons">
     {{- range . }}
-    <a href="{{ trim .url " " }}" target="_blank" rel="noopener noreferrer me" title="{{ .name | title }}">
-        {{ partial "svg.html" . }}
-    </a>
+        {{ if eq (substr (trim .url " ") 0 4) "tel:"}}
+            <a href="{{ trim .url " " | safeURL }}" target="_blank" rel="noopener noreferrer me" title="{{ .name | title }}">
+                {{ partial "svg.html" . }}
+            </a>
+        {{ else }}
+            <a href="{{ trim .url " " }}" target="_blank" rel="noopener noreferrer me" title="{{ .name | title }}">
+                {{ partial "svg.html" . }}
+            </a>
+        {{ end }}
     {{- end }}
 </div>

--- a/layouts/partials/social_icons.html
+++ b/layouts/partials/social_icons.html
@@ -1,13 +1,7 @@
 <div class="social-icons">
     {{- range . }}
-        {{ if eq (substr (trim .url " ") 0 4) "tel:"}}
-            <a href="{{ trim .url " " | safeURL }}" target="_blank" rel="noopener noreferrer me" title="{{ .name | title }}">
-                {{ partial "svg.html" . }}
-            </a>
-        {{ else }}
-            <a href="{{ trim .url " " }}" target="_blank" rel="noopener noreferrer me" title="{{ .name | title }}">
-                {{ partial "svg.html" . }}
-            </a>
-        {{ end }}
+    <a href="{{ trim .url " " }}" target="_blank" rel="noopener noreferrer me" title="{{ .name | title }}">
+        {{ partial "svg.html" . }}
+    </a>
     {{- end }}
 </div>

--- a/layouts/partials/svg.html
+++ b/layouts/partials/svg.html
@@ -313,6 +313,12 @@
         d="M7.144 19.532l1.049-5.751c.11-.606.691-1.002 1.304-.948 2.155.192 6.877.1 8.818-4.002 2.554-5.397-.59-7.769-6.295-7.769H7.43a1.97 1.97 0 0 0-1.944 1.655L2.77 19.507a.857.857 0 0 0 .846.994h2.368a1.18 1.18 0 0 0 1.161-.969zM7.967 22.522a.74.74 0 0 0 .666.416h2.313c.492 0 .923-.351 1.003-.837l.759-4.601c.095-.523.597-.866 1.127-.819 1.86.166 5.567-.118 6.85-3.821.554-1.6.705-2.954.408-4.018"
         style="font-variation-settings:normal" stroke="currentColor" stroke-linejoin="miter" />
 </svg>
+{{- else if (eq $icon_name "phone") -}}
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect x="9" y="4" width="6" height="1" rx="0.5" fill="currentColor"/>
+    <path d="M12 20C12.2652 20 12.5196 19.8946 12.7071 19.7071C12.8946 19.5196 13 19.2652 13 19C13 18.7348 12.8946 18.4804 12.7071 18.2929C12.5196 18.1054 12.2652 18 12 18C11.7348 18 11.4804 18.1054 11.2929 18.2929C11.1054 18.4804 11 18.7348 11 19C11 19.2652 11.1054 19.5196 11.2929 19.7071C11.4804 19.8946 11.7348 20 12 20Z" fill="currentColor"/>
+    <rect x="5" y="1" width="14" height="22" rx="2" stroke="currentColor" stroke-width="2"/>
+</svg>
 {{- else if (eq $icon_name "polywork") -}}
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img"
     fill="currentColor" preserveAspectRatio="xMidYMid meet" viewBox="0 0 24 24">


### PR DESCRIPTION
**What does this PR change? What problem does it solve?**

This PR adds a 'phone' svg (made myself in Figma) and the possibility to use "tel:" as a social url (e.g. "tel:0123456789").

**Was the change discussed in an issue or in the Discussions before?**

No

## PR Checklist

- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have verified that the code works as described/as intended.
- [x] This change adds a Social Icon which has a permissive license to use it.
- [x] This change **does not** include any CDN resources/links.
- [x] This change **does not** include any unrelated scripts such as bash and python scripts.
- [ ] This change updates the overridden internal templates from HUGO's repository.

## Remarks

It might be easier and more sensible to just pass safeURL on all social urls.
