### PR TITLE
Added Fathom analytics partial

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ The [demo](https://adityatelange.github.io/hugo-PaperMod/) includes a lot of doc
 -   Breadcrumb Navigation
 -   Code Block Copy buttons
 -   No webpack, nodejs and other dependencies are required to edit the theme.
+-   [Fathom analytics](https://usefathom.com/ref/FPKJIU) support (Privacy focussed website analytics)
 
 Read Wiki For More Details => **[PaperMod - Features](https://github.com/adityatelange/hugo-PaperMod/wiki/Features)**
 

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -164,5 +164,5 @@
 {{- template "partials/templates/opengraph.html" . }}
 {{- template "partials/templates/twitter_cards.html" . }}
 {{- template "partials/templates/schema_json.html" . }}
-{{- template "partials/templates/fathom_analytics.html"}}
+{{- template "partials/templates/fathom_analytics.html" . }}
 {{- end -}}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -164,4 +164,5 @@
 {{- template "partials/templates/opengraph.html" . }}
 {{- template "partials/templates/twitter_cards.html" . }}
 {{- template "partials/templates/schema_json.html" . }}
+{{- template "partials/templates/fathom_analytics.html"}}
 {{- end -}}

--- a/layouts/partials/templates/fathom_analytics.html
+++ b/layouts/partials/templates/fathom_analytics.html
@@ -1,0 +1,24 @@
+{{/* New to Fathom analytics? Use my affiliate link to get a 10 dollar discount: https://usefathom.com/ref/FPKJIU */}}
+
+{{- if .Site.Params.analytics.fathom.siteId }}
+<script 
+{{- if .Site.Params.analytics.fathom... }}
+{{- else }}
+{{- end}}
+data-site="{{ .Site.Params.analytics.fathom.siteId }}"
+src="{{ .Site.Params.analytics.fathom.customDomain | default "https://cdn.usefathom.com/script.js" }}" 
+{{- if .Site.Params.analytics.fathom.honorDnt }}
+data-honor-dnt="{{ .Site.Params.analytics.fathom.honorDnt }}"
+{{- end}}
+{{- if .Site.Params.analytics.fathom.canonical }}
+data-canonical="{{ .Site.Params.analytics.fathom.canonical }}"
+{{- end}}
+{{- if .Site.Params.analytics.fathom.excludedDomains }}
+data-excluded-domains="{{ .Site.Params.analytics.fathom.excludedDomains }}"
+{{- end}}
+{{- if .Site.Params.analytics.fathom.includedDomains }}
+data-included-domains="{{ .Site.Params.analytics.fathom.includedDomains }}"
+{{- end}}
+defer
+></script>
+{{- end -}}

--- a/layouts/partials/templates/fathom_analytics.html
+++ b/layouts/partials/templates/fathom_analytics.html
@@ -1,23 +1,20 @@
 {{/* New to Fathom analytics? Use my affiliate link to get a 10 dollar discount: https://usefathom.com/ref/FPKJIU */}}
 
-{{- if .Site.Params.analytics.fathom.siteId }}
+{{- if .Site.Params.fathom.siteId }}
 <script 
-{{- if .Site.Params.analytics.fathom... }}
-{{- else }}
+data-site="{{ .Site.Params.fathom.siteId }}"
+src="{{ .Site.Params.fathom.customDomain | default "https://cdn.usefathom.com/script.js" }}" 
+{{- if .Site.Params.fathom.honorDnt }}
+data-honor-dnt="{{ .Site.Params.fathom.honorDnt }}"
 {{- end}}
-data-site="{{ .Site.Params.analytics.fathom.siteId }}"
-src="{{ .Site.Params.analytics.fathom.customDomain | default "https://cdn.usefathom.com/script.js" }}" 
-{{- if .Site.Params.analytics.fathom.honorDnt }}
-data-honor-dnt="{{ .Site.Params.analytics.fathom.honorDnt }}"
+{{- if .Site.Params.fathom.canonical }}
+data-canonical="{{ .Site.Params.fathom.canonical }}"
 {{- end}}
-{{- if .Site.Params.analytics.fathom.canonical }}
-data-canonical="{{ .Site.Params.analytics.fathom.canonical }}"
+{{- if .Site.Params.fathom.excludedDomains }}
+data-excluded-domains="{{ .Site.Params.fathom.excludedDomains }}"
 {{- end}}
-{{- if .Site.Params.analytics.fathom.excludedDomains }}
-data-excluded-domains="{{ .Site.Params.analytics.fathom.excludedDomains }}"
-{{- end}}
-{{- if .Site.Params.analytics.fathom.includedDomains }}
-data-included-domains="{{ .Site.Params.analytics.fathom.includedDomains }}"
+{{- if .Site.Params.fathom.includedDomains }}
+data-included-domains="{{ .Site.Params.fathom.includedDomains }}"
 {{- end}}
 defer
 ></script>

--- a/theme.toml
+++ b/theme.toml
@@ -15,7 +15,8 @@ tags = [
   "blog",
   "minimalist",
   "highlight.js",
-  "search"
+  "search",
+  "fathom analytics"
 ]
 features = [
   "responsive",


### PR DESCRIPTION
<!--

## READ BEFORE OPENING A PR

Thank you for contributing to hugo-PaperMod!
Please fill out the following questions to make it easier for us to review your
changes. You do not need to check all the boxes below.

**NOTE**: PaperMod does not have any external dependencies fetched from 3rd party
CDN servers. However we do have custom Head/Footer extender templates which you can use
to add those to your website.
https://github.com/adityatelange/hugo-PaperMod/wiki/FAQs#custom-head--footer

-->


**What does this PR change? What problem does it solve?**

<!--
Describe the changes and their purpose here, as detailed as and if  needed.

Please do not add 2 unrelated changes in a single PR as it is difficult to track/revert those in future.
-->

Since this is a simple clean and fast theme it would be logical to have an alternative to Google Analytics that is fast, privacy friendly and small. (You do not need to have a cookie banner) To learn more please use my affiliate link this will also give you a 10 dollar discount when you are a new customer. [Learn more](https://usefathom.com/ref/FPKJIU)


**Was the change discussed in an issue or in the Discussions before?**

<!--
Link issues and relevant Discussions posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

No this change was not discussed but I think it would be a great addition. Since this is my first time contributing to this project (I think more will follow) it is still a little new to me how update the wiki pages so in the mean time I will post the updated text here:

To the features page:
```md
1. Add to the table of contents under Misc
2. Add under Misc:

### Fathom analytics
Fathom is website analytics that doesn't suck. It is privacy friendly, fast and by-passes ad-blockers to see everyone on your website. [Learn more](https://usefathom.com/ref/FPKJIU) (This is an affiliate link and will get your a 10 dollar discount)

To start using add the following to your config:
\```yaml
params:
  fathom:
    siteId: "abc123" # Filling this enables the fathom analytics partial otherwise it is excluded
    customDomain: "https://example.com" # When using custom domains supply it here otherwise the global cdn is used
    honorDnt: true # From default fathom ignores do not track request but you can force it to comply
    canonical: true # When false it will not group canonical url's
    excludedDomains: "example.com,localhost" # Domains that are excluded from the results
    includedDomains: "example.com,localhost" # If you want to only track on a single or set of domains
\```
```

For more information please consult the [official documentation](https://usefathom.com/docs/script/script-advanced).

## PR Checklist

- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have verified that the code works as described/as intended.
- [ ] This change adds a Social Icon which has a permissive license to use it.
- [ ] This change **does not** include any CDN resources/links.
- [x] This change **does not** include any unrelated scripts such as bash and python scripts.
- [ ] This change updates the overridden internal templates from HUGO's repository.
