### PR TITLE
Fix typo in exampleSite/markdown-syntax.md

### DIFF
--- a/content/posts/markdown-syntax.fa.md
+++ b/content/posts/markdown-syntax.fa.md
@@ -56,7 +56,7 @@ The blockquote element represents content that is quoted from another source, op
 
 ## Tables
 
-Tables aren't part of the core Markdown spec, but Hugo supports supports them out-of-the-box.
+Tables aren't part of the core Markdown spec, but Hugo supports them out-of-the-box.
 
 | Name  | Age |
 | ----- | --- |

--- a/content/posts/markdown-syntax.fr.md
+++ b/content/posts/markdown-syntax.fr.md
@@ -56,7 +56,7 @@ The blockquote element represents content that is quoted from another source, op
 
 ## Tables
 
-Tables aren't part of the core Markdown spec, but Hugo supports supports them out-of-the-box.
+Tables aren't part of the core Markdown spec, but Hugo supports them out-of-the-box.
 
 | Name  | Age |
 | ----- | --- |

--- a/content/posts/markdown-syntax.md
+++ b/content/posts/markdown-syntax.md
@@ -56,7 +56,7 @@ The blockquote element represents content that is quoted from another source, op
 
 ## Tables
 
-Tables aren't part of the core Markdown spec, but Hugo supports supports them out-of-the-box.
+Tables aren't part of the core Markdown spec, but Hugo supports them out-of-the-box.
 
 | Name  | Age |
 | ----- | --- |


### PR DESCRIPTION

**What does this PR change? What problem does it solve?**

Fixed typo in markdown-syntax test files: the word "supports" duplicated


**Was the change discussed in an issue or in the Discussions before?**

No, it was not.


## PR Checklist

- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have verified that the code works as described/as intended.
- [ ] This change adds a Social Icon which has a permissive license to use it.
- [x] This change **does not** include any CDN resources/links.
- [x] This change **does not** include any unrelated scripts such as bash and python scripts.
- [ ] This change updates the overridden internal templates from HUGO's repository.
