### PR TITLE
Fix breadcrumbs displaying problem

### DIFF
--- a/layouts/partials/breadcrumbs.html
+++ b/layouts/partials/breadcrumbs.html
@@ -11,7 +11,7 @@
     {{- $bc_pg := $.Site.GetPage ($scratch.Get "path") -}}
 
     {{- if (and ($bc_pg) (gt (len . ) 0))}}
-    {{- print "&nbsp;»&nbsp;" | safeHTML -}}<a href="{{ $bc_pg.Permalink }}">{{ $bc_pg.Name }}</a>
+    {{- print "&nbsp;»&nbsp;" | safeHTML -}}<a href="{{ $bc_pg.Permalink }}">{{ path.Base $bc_pg.Dir }}</a>
     {{- end }}
 
     {{- end -}}


### PR DESCRIPTION
**What does this PR change? What problem does it solve?**
To fix breadcrumbs displaying problem

old one -> 
![Screenshot 2021-12-25 at 11-52-45 LaTeX Starter](https://user-images.githubusercontent.com/39305460/147377052-5b9ea46f-da35-4b6d-8966-03a345b3f65c.png)

new one -> 
![Screenshot 2021-12-25 at 11-52-02 LaTeX Starter](https://user-images.githubusercontent.com/39305460/147377053-77c18969-dbb9-4b23-8302-210cb684a741.png)


**Was the change discussed in an issue or in the Discussions before?**
No, I didn't find something related


## PR Checklist

- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have verified that the code works as described/as intended.
- [ ] This change adds a Social Icon which has a permissive license to use it.
- [x] This change **does not** include any CDN resources/links.
- [x] This change **does not** include any unrelated scripts such as bash and python scripts.
- [ ] This change updates the overridden internal templates from HUGO's repository.
