### PR TITLE
Improve codeblock borders

### DIFF
--- a/assets/css/common/main.css
+++ b/assets/css/common/main.css
@@ -49,6 +49,10 @@ pre {
     position: relative;
 }
 
+div.highlight div {
+    background-color: var(--theme) !important;
+}
+
 .copy-code {
     display: none;
     position: absolute;

--- a/assets/css/common/post-single.css
+++ b/assets/css/common/post-single.css
@@ -160,7 +160,7 @@
     border-radius: var(--radius);
 }
 
-.post-content table pre {
+.post-content .highlight table pre {
     border-radius: 0;
 }
 

--- a/assets/css/common/post-single.css
+++ b/assets/css/common/post-single.css
@@ -160,6 +160,10 @@
     border-radius: var(--radius);
 }
 
+.post-content table pre {
+    border-radius: 0;
+}
+
 .post-content li > .highlight {
     margin-inline-end: 0;
 }


### PR DESCRIPTION
**What does this PR change? What problem does it solve?**

This PR resolves two formatting issues with code block borders. The following screenshot demonstrates the problem:

![image](https://user-images.githubusercontent.com/49147108/147380535-5914ce54-a3d4-41f9-aa74-813f0284c1ec.png)

1. The background color behind the rounded borders does obviously not match the selected theme (dark).
2. The border-radius between the line numbers and the actual code creates an annoying gap,

The first issue was solved by changing the background color of `<div>` elements inside a `<div class="highlight">` element. Unfortunately, *hugo* does not assign a special class for these elements, so the selector is not very specific. However, during my tests it did not cause any side effects.

The second issue was solved by adding a *CSS* rule that applies to pre blocks inside a table. The *CSS* rule that introduces the radius initially has a filter `.post-content .highlight:not(table)`, so you probably tried already to exclude the elements within a table. However, this does not work for me as one can see in the screenshot above. Adding a dedicated selector for  pre elements inside a table and resetting the radius does the trick.

Here is a screenshot of the code block with the applied modifications:

![image](https://user-images.githubusercontent.com/49147108/147380763-080c1292-502d-48d5-b91c-8590bb36f21a.png)

When disabling line numbers, the code block is still displayed correctly (here with the light theme):

![image](https://user-images.githubusercontent.com/49147108/147380793-81024f66-2bb5-48b9-a550-0b5f3cdbc40e.png)

**Was the change discussed in an issue or in the Discussions before?**

No


## PR Checklist

- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have verified that the code works as described/as intended.
- [ ] This change adds a Social Icon which has a permissive license to use it.
- [x] This change **does not** include any CDN resources/links.
- [x] This change **does not** include any unrelated scripts such as bash and python scripts.
- [ ] This change updates the overridden internal templates from HUGO's repository.
