### PR TITLE
Add support for displaying social icons in footer

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,5 +1,12 @@
 {{- if not (.Param "hideFooter") }}
 <footer class="footer">
+    {{ if and (.Site.Params.SocialIconsFooter) (not .Params.HideSocialIconsFooter) }}
+        {{ if or (.Site.Params.SocialIconsFooterHome) (not .IsHome) }}
+            {{ if not (in .Site.Params.HideSocialIconsFooterSections .Section) }}
+                {{ partial "social_icons.html" $.Site.Params.socialIcons }}
+            {{ end }}
+        {{ end }}
+    {{ end }}
     {{- if .Site.Copyright }}
     <span>{{ .Site.Copyright | markdownify }}</span>
     {{- else }}


### PR DESCRIPTION
**What does this PR change? What problem does it solve?**

This PR adds the following new options to the Site params:

* SocialIconsFooter
* SocialIconsFooterHome
* HideSocialIconsFooterSections:

The first one can be used to display social icons within the footer for
all pages except the homepage. The second one can be set to true to also
display social icons within the homepage. The last one is a list and can
be used to hide social icons on specific sections.

Furthermore, each page can include the page param HideSocialIconsFooter
to prevent social icons from being displayed within the footer.

I use these settings for my personal blog and thought they might be useful for others. This is how the footer looks like when applying the changes:

![image](https://user-images.githubusercontent.com/49147108/147401720-5eab4b5b-2f8c-4da3-802e-fa05c8cbcd7a.png)


**Was the change discussed in an issue or in the Discussions before?**

No.

## PR Checklist

- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have verified that the code works as described/as intended.
- [ ] This change adds a Social Icon which has a permissive license to use it.
- [x] This change **does not** include any CDN resources/links.
- [x] This change **does not** include any unrelated scripts such as bash and python scripts.
- [ ] This change updates the overridden internal templates from HUGO's repository.

## Acknowledgements

The original idea was taken from [this blog](https://kpwn.de/2021/09/how-to-set-up-this-blog/) by @KwnyPwny
