### PR TITLE
Add korean translations

### DIFF
--- a/i18n/ko.yaml
+++ b/i18n/ko.yaml
@@ -3,3 +3,23 @@
 
 - id: next_page
   translation: "다음 페이지"
+
+- id: read_time
+  translation:
+    one : "1 분"
+    other: "{{ .Count }} 분"
+
+- id: toc
+  translation: "목차"
+
+- id: translations
+  translation: "번역"
+
+- id: home
+  translation: "홈페이지"
+
+- id: code_copy
+  translation: "복사"
+
+- id: code_copied
+  translation: "복사완료!"


### PR DESCRIPTION
**What does this PR change? What problem does it solve?**

Add missing translations for Korean language.


**Was the change discussed in an issue or in the Discussions before?**

No, it was not.


## PR Checklist

- [x] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have verified that the code works as described/as intended.
- [ ] This change adds a Social Icon which has a permissive license to use it.
- [x] This change **does not** include any CDN resources/links.
- [x] This change **does not** include any unrelated scripts such as bash and python scripts.
- [ ] This change updates the overridden internal templates from HUGO's repository.
