### PR TITLE
Fix share URL

### DIFF
--- a/layouts/partials/share_icons.html
+++ b/layouts/partials/share_icons.html
@@ -1,4 +1,4 @@
-{{- $pageurl := .Permalink }}
+{{- $pageurl := .Page.Permalink }}
 {{- $title := .Title }}
 
 {{- $.Scratch.Set "tags" ""}}


### PR DESCRIPTION
<!--

## READ BEFORE OPENING A PR

Thank you for contributing to hugo-PaperMod!
Please fill out the following questions to make it easier for us to review your
changes. You do not need to check all the boxes below.

**NOTE**: PaperMod does not have any external dependencies fetched from 3rd party
CDN servers. However we do have custom Head/Footer extender templates which you can use
to add those to your website.
https://github.com/adityatelange/hugo-PaperMod/wiki/FAQs#custom-head--footer

-->


**What does this PR change? What problem does it solve?**

Fixes URL for share buttons. Currently, if you try to use share buttons in the bottom of the page, you will get a wron link. For example, on Twitter:

![Screenshot 2022-01-05 at 23 40 34](https://user-images.githubusercontent.com/15696488/148299885-81db7eb4-3670-492e-9cbb-5d5c930c283c.png)

I believe, this is caused by an error in obtaining the page URL. [This answer](https://discourse.gohugo.io/t/how-to-get-the-url-of-the-current-page-with-the-rel-or-relref-function/29113/4) on the Hugo forum has some more details.

Quick test with the local server:

![Screenshot 2022-01-05 at 23 43 23](https://user-images.githubusercontent.com/15696488/148300169-b2b3a13e-761f-4a61-aaf0-bf9c74cad9a1.png)

**Was the change discussed in an issue or in the Discussions before?**

I couldn't find a relevant issue, but I can create one if required.

## PR Checklist

- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have verified that the code works as described/as intended.
- [ ] This change adds a Social Icon which has a permissive license to use it.
- [x] This change **does not** include any CDN resources/links.
- [x] This change **does not** include any unrelated scripts such as bash and python scripts.
- [ ] This change updates the overridden internal templates from HUGO's repository.
