### PR TITLE
Fall back post author to '.Site.Author.name' when it is not set.

### DIFF
--- a/layouts/partials/author.html
+++ b/layouts/partials/author.html
@@ -1,5 +1,5 @@
-{{- if or .Params.author .Site.Params.author }}
-{{- $author := (.Params.author | default .Site.Params.author) }}
+{{- if or .Params.author .Site.Params.author .Site.Author.name }}
+{{- $author := (.Params.author | default .Site.Params.author | default .Site.Author.name) }}
 {{- $author_type := (printf "%T" $author) }}
 {{- if (or (eq $author_type "[]string") (eq $author_type "[]interface {}")) }}
 {{- (delimit $author ", " ) }}


### PR DESCRIPTION
'.Site.Author' is a recognized Hugo site variable, c.f. [1].

It's also already used elsewhere within PaperMod, namely in rss.xml.

By falling back to this variable users' configs can be simplified, being
effectively unnecessary to set the author twice, in .Site.Params.author.

[1]: c.f. https://gohugo.io/variables/site/#site-variables-list

<!--

## READ BEFORE OPENING A PR

Thank you for contributing to hugo-PaperMod!
Please fill out the following questions to make it easier for us to review your
changes. You do not need to check all the boxes below.

**NOTE**: PaperMod does not have any external dependencies fetched from 3rd party
CDN servers. However we do have custom Head/Footer extender templates which you can use
to add those to your website.
https://github.com/adityatelange/hugo-PaperMod/wiki/FAQs#custom-head--footer

-->


**What does this PR change? What problem does it solve?**

c.f. commit message.

<!--
Describe the changes and their purpose here, as detailed as and if  needed.

Please do not add 2 unrelated changes in a single PR as it is difficult to track/revert those in future.
-->


**Was the change discussed in an issue or in the Discussions before?**

No.

<!--
Link issues and relevant Discussions posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

N/A

## PR Checklist

- [N/A] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have verified that the code works as described/as intended - verified in my hugo site
- [N/A] This change adds a Social Icon which has a permissive license to use it.
- [x] This change **does not** include any CDN resources/links.
- [x] This change **does not** include any unrelated scripts such as bash and python scripts.
- [x] This change updates the overridden internal templates from HUGO's repository.
