### PR TITLE
Add option to add word count to metadata. Closes #735

### DIFF
--- a/i18n/de.yaml
+++ b/i18n/de.yaml
@@ -9,6 +9,11 @@
     one: "1 min"
     other: "{{ .Count }} min"
 
+- id: words
+  translation:
+    one : "Wort"
+    other: "{{ .Count }} Wörter"
+
 - id: toc
   translation: "Inhaltsverzeichnis"
 

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -9,6 +9,11 @@
     one : "1 min"
     other: "{{ .Count }} min"
 
+- id: words
+  translation:
+    one : "word"
+    other: "{{ .Count }} words"
+
 - id: toc
   translation: "Table of Contents"
 

--- a/i18n/es.yaml
+++ b/i18n/es.yaml
@@ -9,6 +9,11 @@
     one : "1 min"
     other: "{{ .Count }} min"
 
+- id: words
+  translation:
+    one : "palabra"
+    other: "{{ .Count }} palabras"
+
 - id: toc
   translation: "Tabla de Contenidos"
 

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -9,6 +9,11 @@
     one : "1 min"
     other: "{{ .Count }} min"
 
+- id: words
+  translation:
+    one : "mot"
+    other: "{{ .Count }} mots"
+
 - id: toc
   translation: "Table des Matières"
 

--- a/i18n/it.yaml
+++ b/i18n/it.yaml
@@ -9,6 +9,11 @@
     one: "1 minuto"
     other: "{{ .Count }} minuti"
 
+- id: words
+  translation:
+    one : "parola"
+    other: "{{ .Count }} parole"
+
 - id: toc
   translation: "Tabella dei Contenuti"
 

--- a/i18n/nl.yaml
+++ b/i18n/nl.yaml
@@ -9,6 +9,11 @@
       one: "1 min"
       other: "{{ .Count }} min"
 
+- id: words
+  translation:
+    one : "woord"
+    other: "{{ .Count }} woorden"
+
 - id: toc
   translation: "Inhoudsopgave"
 

--- a/i18n/pt.yaml
+++ b/i18n/pt.yaml
@@ -9,6 +9,11 @@
     one: "1 minuto"
     other: "{{ .Count }} minutos"
 
+- id: words
+  translation:
+    one : "palavra"
+    other: "{{ .Count }} palavras"
+
 - id: toc
   translation: "Conteúdo"
 

--- a/layouts/partials/post_meta.html
+++ b/layouts/partials/post_meta.html
@@ -8,6 +8,10 @@
 {{- $scratch.Add "meta" (slice (i18n "read_time" .ReadingTime | default (printf "%d min" .ReadingTime))) }}
 {{- end }}
 
+{{- if (.Param "ShowWordCount") -}}
+{{- $scratch.Add "meta" (slice (i18n "words" .WordCount | default (printf "%d words" .WordCount))) }}
+{{- end }}
+
 {{- with (partial "author.html" .) }}
 {{- $scratch.Add "meta" (slice .) }}
 {{- end }}


### PR DESCRIPTION
Reading time is subjective and relative. Word count is absolute and a
more reliable and traditional proxy to estimate how long a post is. It's
not perfect, and there are variations across languages, hence an option
would leave it to users to decide whether it's relevant to their use
cases.

Introduce a ShowWordCount option and use it in post_meta.html.

Hugo supports word counts natively, c.f.
https://gohugo.io/variables/page/#page-variables

<!--

## READ BEFORE OPENING A PR

Thank you for contributing to hugo-PaperMod!
Please fill out the following questions to make it easier for us to review your
changes. You do not need to check all the boxes below.

**NOTE**: PaperMod does not have any external dependencies fetched from 3rd party
CDN servers. However we do have custom Head/Footer extender templates which you can use
to add those to your website.
https://github.com/adityatelange/hugo-PaperMod/wiki/FAQs#custom-head--footer

-->


**What does this PR change? What problem does it solve?**

<!--
Describe the changes and their purpose here, as detailed as and if  needed.

Please do not add 2 unrelated changes in a single PR as it is difficult to track/revert those in future.
-->

c.f. commit description above

**Was the change discussed in an issue or in the Discussions before?**

<!--
Link issues and relevant Discussions posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

See https://github.com/adityatelange/hugo-PaperMod/issues/735

## PR Checklist

- [x] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have verified that the code works as described/as intended. --> tested on my blog with 'en' and 'pt', verified it works as expected
- [N/A] This change adds a Social Icon which has a permissive license to use it.
- [x] This change **does not** include any CDN resources/links.
- [x] This change **does not** include any unrelated scripts such as bash and python scripts.
- [x] This change updates the overridden internal templates from HUGO's repository.
