### PR TITLE
Update share_icons.html

### DIFF
--- a/layouts/partials/share_icons.html
+++ b/layouts/partials/share_icons.html
@@ -13,6 +13,8 @@
 {{- $ShareButtons := (.Param "ShareButtons")}}
 {{- with $ShareButtons }}{{ $custom = true }}{{ end }}
 
+{{- if (.Param "ShowShareButtons") -}}
+
 <div class="share-buttons">
     {{- if (cond ($custom) (in $ShareButtons "twitter") (true)) }}
     <a target="_blank" rel="noopener noreferrer" aria-label="share {{ $title | plainify }} on twitter"
@@ -69,3 +71,5 @@
     </a>
     {{- end }}
 </div>
+
+{{- end }}


### PR DESCRIPTION
<!--

## READ BEFORE OPENING A PR

Thank you for contributing to hugo-PaperMod!
Please fill out the following questions to make it easier for us to review your
changes. You do not need to check all the boxes below.

**NOTE**: PaperMod does not have any external dependencies fetched from 3rd party
CDN servers. However we do have custom Head/Footer extender templates which you can use
to add those to your website.
https://github.com/adityatelange/hugo-PaperMod/wiki/FAQs#custom-head--footer

-->


**What does this PR change? What problem does it solve?**

The `ShowShareButtons: false` parameter is currently not functional when included in single files. By encasing the `share-buttons` div here with `{{- if (.Param "ShowShareButtons") -}}`, this functionality is restored.

<!--
Describe the changes and their purpose here, as detailed as and if  needed.

Please do not add 2 unrelated changes in a single PR as it is difficult to track/revert those in future.
-->


**Was the change discussed in an issue or in the Discussions before?**

Not that I could find.

<!--
Link issues and relevant Discussions posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->


## PR Checklist

- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [ ] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [X] I have verified that the code works as described/as intended.
- [ ] This change adds a Social Icon which has a permissive license to use it.
- [X] This change **does not** include any CDN resources/links.
- [X] This change **does not** include any unrelated scripts such as bash and python scripts.
- [ ] This change updates the overridden internal templates from HUGO's repository.
