### PR TITLE
Remove duplicate call to hugo.Generator

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -104,9 +104,6 @@
 <meta name="theme-color" content="{{ .Site.Params.assets.theme_color | default "#2e2e33" }}">
 <meta name="msapplication-TileColor" content="{{ .Site.Params.assets.msapplication_TileColor | default "#2e2e33" }}">
 
-{{- /* Generator */}}
-{{ hugo.Generator }}
-
 {{- /* RSS */}}
 {{ range .AlternativeOutputFormats -}}
 <link rel="{{ .Rel }}" type="{{ .MediaType.Type | html }}" href="{{ .Permalink | safeURL }}">


### PR DESCRIPTION
Currently, the theme adds the

```
<meta name="generator" content="Hugo 0.92.1" />
```

tag to every page (source: https://github.com/adityatelange/hugo-PaperMod/blob/master/layouts/partials/head.html#L107-L108). 

Problems with this:

1. it doesn't respect the `disableHugoGeneratorInject` setting
2. it differs from the intention of the tag, which is to only appear on the _main_ page (see documentation [here](https://gohugo.io/getting-started/configuration/#disablehugogeneratorinject) and comment by `bep` [here](https://github.com/gohugoio/hugo/issues/5048#issuecomment-411322950))

The solution is really simple: For some versions now, the theme doesn't have to add the tag anymore. If it's not present, `hugo` will just add it (if `disableHugoGeneratorInject` isn't `true`). So removing this code and using the latest version of hugo gives you the intended behaviour.


## PR Checklist

- [ ] ~This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).~
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have verified that the code works as described/as intended.
- [ ] ~This change adds a Social Icon which has a permissive license to use it.~
- [x] This change **does not** include any CDN resources/links.
- [x] This change **does not** include any unrelated scripts such as bash and python scripts.
- [ ] ~This change updates the overridden internal templates from HUGO's repository.~
