### PR TITLE
Fix multilingual tags not showing up in self-defined taxonomy and multilingual search issue

### DIFF
--- a/assets/js/fastsearch.js
+++ b/assets/js/fastsearch.js
@@ -48,7 +48,7 @@ window.onload = function () {
             }
         }
     };
-    xhr.open('GET', "../index.json");
+    xhr.open('GET', jsonLangUrl); // Using Relative Path to Base URL instead of to current directory
     xhr.send();
 }
 

--- a/i18n/ar.yaml
+++ b/i18n/ar.yaml
@@ -20,3 +20,6 @@
   
 - id: home
   translation: "الصفحة الرئيسية"
+
+- id: tags
+  translation: "العلامات"

--- a/i18n/bg.yaml
+++ b/i18n/bg.yaml
@@ -14,3 +14,6 @@
 
 - id: translations
   translation: "Преводи"
+
+- id: tags
+  translation: "етикети"

--- a/i18n/ca.yaml
+++ b/i18n/ca.yaml
@@ -17,3 +17,6 @@
 
 - id: home
   translation: "Inici"
+
+- id: tags
+  translation: "Etiquetes"

--- a/i18n/da.yaml
+++ b/i18n/da.yaml
@@ -26,3 +26,6 @@
 
 - id: code_copied
   translation: "kopieret!"
+
+- id: tags
+  translation: "tags"

--- a/i18n/de.yaml
+++ b/i18n/de.yaml
@@ -31,3 +31,6 @@
 
 - id: code_copied
   translation: "Kopiert!"
+
+- id: tags
+  translation: "Stichworte"

--- a/i18n/eo.yaml
+++ b/i18n/eo.yaml
@@ -23,3 +23,6 @@
 
 - id: code_copied
   translation: "kopiite!"
+
+- id: tags
+  translation: "etikedoj"

--- a/i18n/es.yaml
+++ b/i18n/es.yaml
@@ -31,3 +31,6 @@
 
 - id: code_copied
   translation: "¡copiado!"
+
+- id: tags
+  translation: "etiquetas"

--- a/i18n/fa.yaml
+++ b/i18n/fa.yaml
@@ -26,3 +26,6 @@
 
 - id: code_copied
   translation: "کپی شد!"
+
+- id: tags
+  translation: "برچسب ها"

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -31,3 +31,6 @@
 
 - id: code_copied
   translation: "copié!"
+
+- id: tags
+  translation: "Mots clés"

--- a/i18n/he.yaml
+++ b/i18n/he.yaml
@@ -17,3 +17,6 @@
 
 - id: home
   translation: "דף בית"
+
+- id: tags
+  translation: "תגים"

--- a/i18n/hi.yaml
+++ b/i18n/hi.yaml
@@ -14,3 +14,6 @@
 
 - id: translations
   translation: "अनुवाद"
+
+- id: tags
+  translation: "टैग"

--- a/i18n/hu.yaml
+++ b/i18n/hu.yaml
@@ -14,3 +14,6 @@
 
 - id: translations
   translation: "Fordítások"
+
+- id: tags
+  translation: "Címkéket"

--- a/i18n/id.yaml
+++ b/i18n/id.yaml
@@ -14,3 +14,6 @@
 
 - id: translations
   translation: "Terjemahan"
+
+- id: tags
+  translation: "Tag"

--- a/i18n/it.yaml
+++ b/i18n/it.yaml
@@ -25,3 +25,6 @@
 
 - id: code_copied
   translation: "copiato!"
+
+- id: tags
+  translation: "tag"

--- a/i18n/ja.yaml
+++ b/i18n/ja.yaml
@@ -14,3 +14,6 @@
 
 - id: translations
   translation: "言語"
+
+- id: tags
+  translation: "タグ"

--- a/i18n/ko.yaml
+++ b/i18n/ko.yaml
@@ -23,3 +23,6 @@
 
 - id: code_copied
   translation: "복사완료!"
+
+- id: tags
+  translation: "태그"

--- a/i18n/mn.yaml
+++ b/i18n/mn.yaml
@@ -23,3 +23,6 @@
 
 - id: code_copied
   translation: "хуулсан!"
+
+- id: tags
+  translation: "шошго"

--- a/i18n/pl.yaml
+++ b/i18n/pl.yaml
@@ -26,3 +26,6 @@
 
 - id: code_copied
   translation: "Skopiowano!"
+
+- id: tags
+  translation: "Tagi"

--- a/i18n/pt.yaml
+++ b/i18n/pt.yaml
@@ -19,3 +19,6 @@
 
 - id: translations
   translation: "Traduções"
+
+- id: tags
+  translation: "Tag"

--- a/i18n/ru.yaml
+++ b/i18n/ru.yaml
@@ -21,3 +21,6 @@
 
 - id: code_copied
   translation: "скопировано!"
+
+- id: tags
+  translation: "теги"

--- a/i18n/tr.yaml
+++ b/i18n/tr.yaml
@@ -23,3 +23,6 @@
 
 - id: code_copied
   translation: "Kopyalandı!"
+
+- id: tags
+  translation: "Etiketler"

--- a/i18n/uk.yaml
+++ b/i18n/uk.yaml
@@ -23,3 +23,6 @@
 
 - id: code_copied
   translation: "скопійовано!"
+
+- id: tags
+  translation: "теги"

--- a/i18n/uz.yaml
+++ b/i18n/uz.yaml
@@ -18,3 +18,5 @@
 - id: home
   translation: "Bosh sahifa"
   
+- id: tags
+  translation: "Teglar"

--- a/i18n/vi.yaml
+++ b/i18n/vi.yaml
@@ -23,3 +23,6 @@
 
 - id: code_copied
   translation: "Đã sao chép!"
+
+- id: tags
+  translation: "thẻ"

--- a/i18n/zh-tw.yaml
+++ b/i18n/zh-tw.yaml
@@ -26,3 +26,6 @@
 
 - id: code_copied
   translation: "已複製！"
+
+- id: tags
+  translation: "標籤"

--- a/i18n/zh.yaml
+++ b/i18n/zh.yaml
@@ -26,3 +26,6 @@
 
 - id: code_copied
   translation: "已复制！"
+
+- id: tags
+  translation: "标签"

--- a/layouts/_default/search.html
+++ b/layouts/_default/search.html
@@ -21,6 +21,10 @@
 </header>
 
 <div id="searchbox">
+    <!--Create Relative Link for Multilingual Search to avoid invalid URL problem-->
+    <script>
+        var jsonLangUrl = {{"/index.json" | relLangURL}};
+    </script>
     <input id="searchInput" autofocus placeholder="{{ .Params.placeholder | default (printf "%s ↵" .Title) }}"
         aria-label="search" type="search" autocomplete="off">
     <ul id="searchResults" aria-label="search results"></ul>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -36,13 +36,13 @@
   {{- end }}
 
   <footer class="post-footer">
-    {{- if .Params.tags }}
+    {{- if isset .Params (i18n "tags" | default "tags")}}
     <ul class="post-tags">
-      {{- range ($.GetTerms "tags") }}
+      {{- range ($.GetTerms (i18n "tags" | default "tags")) }}
       <li><a href="{{ .Permalink }}">{{ .LinkTitle }}</a></li>
       {{- end }}
     </ul>
-    {{- end }}
+    {{- end}}
     {{- if (.Param "ShowPostNavLinks") }}
     {{- partial "post_nav_links.html" . }}
     {{- end }}


### PR DESCRIPTION
I found that originally, only taxonomies with name "tags" would show up in posts. However this brings a problem: if one created a multilingual site with self-defined taxonomy, namely not using "tags" but the corresponding word in their own languages as the taxonomy term, "etiquetas" in Spanish, for example, then the tags will never show up in posts properly. This issue was not discussed before.

If one used "tags" as the taxonomy term, then the tag page's title will be "tags" instead of its translation. Imagine a page full of Spanish tags with an English title "Tags", while other entries remain Spanish. Weird, isn't it?

I tried to fix the problem by changing the {{.Title}} keyword in terms.html to {{i18n .Title}}, but it didn't fix the problem fully cause the head still uses .Title instead of its i18n version.

So in the end I changed the taxonomy layout. I made two changes:

1. Changed {{- if .Params.tags}} to {{- if isset .Params (i18n "tags" | default "tags")}} to check if the user has defined a different name for "tags" as their own taxonomy term.
2. Changed {{- range ($.GetTerms "tags") }} to {{- range ($.GetTerms (i18n "tags" | default "tags")) }} so that the tags could be ranged over properly.

These changes will allow user to use Taxonomy terms of "tags" in their own languages and at the same time, tags will appear on their posts correctly. For example, if a Spanish used "etiquetas" as taxonomy term for tag, the etiquetas will not show up in the posts at all before this change. However, after these changes, the etiquetas would show up properly. However, the user need to check the i18n translation files to find/set their taxonomy terms accordingly.

I tried to add corresponding translation in the i18n file except for central Kurdish and Bengali because I am unable to Google translate them.

## PR Checklist

- [x] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [ ] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have verified that the code works as described/as intended.
- [ ] This change adds a Social Icon which has a permissive license to use it.
- [x] This change **does not** include any CDN resources/links.
- [x] This change **does not** include any unrelated scripts such as bash and python scripts.
- [ ] This change updates the overridden internal templates from HUGO's repository.
