### PR TITLE
Add social icon for Bilibili

### DIFF
--- a/layouts/partials/svg.html
+++ b/layouts/partials/svg.html
@@ -21,6 +21,14 @@
         style="font-variation-settings:normal"
         d="M1.774 18.063V5.466h5.51c1.978 0 3.116 1.326 3.055 2.806-.043 1.049-.711 2.988-2.643 2.988h-5.93H7.73c1.224 0 3.532 1.13 3.532 3.532 0 2.4-1.873 3.27-3.318 3.27zm12.57-4.459h7.89s.012-4.18-4.167-4.18c-5.237 0-5.277 9.11-.3 9.11 3.06 0 3.935-1.806 3.935-1.806M15.526 5.823h4.987" />
 </svg>
+{{- else if (eq $icon_name "bilibili") -}}
+<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" xmlns="http://www.w3.org/2000/svg">
+    <rect x="1.3333" y="6" width="21.333" height="15.333" rx="4" ry="4"/>
+    <path d="m8 12.4v1.2"/>
+    <path d="m16 12.4v1.2"/>
+    <path d="m5.8853 2.6667 2.6667 2.6667"/>
+    <path d="m18.115 2.6667-2.6667 2.6667"/>
+</svg>
 {{- else if (eq $icon_name "buymeacoffee") -}}
 <svg viewBox="0 0 884 1279" fill="none" stroke="currentColor" stroke-width="2" xmlns="http://www.w3.org/2000/svg">
     <path d="M791.109 297.518L790.231 297.002L788.201 296.383C789.018 297.072 790.04 297.472 791.109 297.518Z"


### PR DESCRIPTION
**What does this PR change? What problem does it solve?**

Adds social icon for [bilibili](https://www.bilibili.com) which is a Chinese video service modeled after the Japanese niconico.

The icon is re-drawn by myself to use outlines (the simpleicons version is using fills, which appears to be 2.66px thick instead of the consistent 2px, as the original Bilibili version is 18x18 with 2px strokes converted to fills too).

**Was the change discussed in an issue or in the Discussions before?**

n/a

## PR Checklist

- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have verified that the code works as described/as intended.
- [x] This change adds a Social Icon which has a permissive license to use it.
- [x] This change **does not** include any CDN resources/links.
- [x] This change **does not** include any unrelated scripts such as bash and python scripts.
- [ ] This change updates the overridden internal templates from HUGO's repository.
