### PR TITLE
add robotsNoIndex parameter

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,7 +1,7 @@
 <meta charset="utf-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-{{- if hugo.IsProduction | or (eq site.Params.env "production") }}
+{{- if hugo.IsProduction | or (eq site.Params.env "production") | and (ne .Params.robotsNoIndex true) }}
 <meta name="robots" content="index, follow">
 {{- else }}
 <meta name="robots" content="noindex, nofollow">

--- a/layouts/robots.txt
+++ b/layouts/robots.txt
@@ -1,6 +1,12 @@
 User-agent: *
 {{- if hugo.IsProduction | or (eq site.Params.env "production") }}
+{{- $noIndexPages := where .Site.Pages "Params.robotsNoIndex" true }}
+{{- range $noIndexPages }}
+Disallow: {{ .RelPermalink }}
+{{- end }}
+{{- if not $noIndexPages }}
 Disallow:
+{{- end }}
 {{- else }}
 Disallow: /
 {{- end }}

--- a/layouts/robots.txt
+++ b/layouts/robots.txt
@@ -1,12 +1,6 @@
 User-agent: *
 {{- if hugo.IsProduction | or (eq site.Params.env "production") }}
-{{- $noIndexPages := where .Site.Pages "Params.robotsNoIndex" true }}
-{{- range $noIndexPages }}
-Disallow: {{ .RelPermalink }}
-{{- end }}
-{{- if not $noIndexPages }}
 Disallow:
-{{- end }}
 {{- else }}
 Disallow: /
 {{- end }}


### PR DESCRIPTION
**What does this PR change? What problem does it solve?**
This PR adds the ability to use the `noindex` and `nofollow` parameters for specific pages in production mode, preventing e.g. the imprint from showing up in search engines. It also lists these pages in the `robots.txt` file.

**Was the change discussed in an issue or in the Discussions before?**
https://github.com/adityatelange/hugo-PaperMod/pull/712 also touches this line, but it adds other functionality as well and doesn't include `robots.txt`.

Cheers!

## PR Checklist

- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have verified that the code works as described/as intended.
- [ ] This change adds a Social Icon which has a permissive license to use it.
- [x] This change **does not** include any CDN resources/links.
- [x] This change **does not** include any unrelated scripts such as bash and python scripts.
- [x] This change updates the overridden internal templates from HUGO's repository.
