### PR TITLE
i18n: Add translation support for "draft"

### DIFF
--- a/i18n/de.yaml
+++ b/i18n/de.yaml
@@ -31,3 +31,6 @@
 
 - id: code_copied
   translation: "Kopiert!"
+
+- id: draft
+  translation: "Entwurf"

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -31,3 +31,6 @@
 
 - id: code_copied
   translation: "copied!"
+
+- id: draft
+  translation: "draft"

--- a/layouts/_default/archives.html
+++ b/layouts/_default/archives.html
@@ -30,7 +30,7 @@
       <div class="archive-entry">
         <h3 class="archive-entry-title">
           {{- .Title | markdownify }}
-          {{- if .Draft }}<sup><span class="entry-isdraft">&nbsp;&nbsp;[draft]</span></sup>{{- end }}
+          {{- if .Draft }}<sup><span class="entry-isdraft">&nbsp;&nbsp;[{{ default (i18n "draft" | default "draft") }}]</span></sup>{{- end }}
         </h3>
         <div class="archive-meta">
           {{- partial "post_meta.html" . -}}

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -66,7 +66,7 @@
   <header class="entry-header">
     <h2>
       {{- .Title }}
-      {{- if .Draft }}<sup><span class="entry-isdraft">&nbsp;&nbsp;[draft]</span></sup>{{- end }}
+      {{- if .Draft }}<sup><span class="entry-isdraft">&nbsp;&nbsp;[{{ default (i18n "draft" | default "draft") }}]</span></sup>{{- end }}
     </h2>
   </header>
   {{- if (ne (.Param "hideSummary") true) }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -5,7 +5,7 @@
     {{ partial "breadcrumbs.html" . }}
     <h1 class="post-title">
       {{ .Title }}
-      {{- if .Draft }}<sup><span class="entry-isdraft">&nbsp;&nbsp;[draft]</span></sup>{{- end }}
+      {{- if .Draft }}<sup><span class="entry-isdraft">&nbsp;&nbsp;[{{ default (i18n "draft" | default "draft") }}]</span></sup>{{- end }}
     </h1>
     {{- if .Description }}
     <div class="post-description">


### PR DESCRIPTION
**What does this PR change? What problem does it solve?**

Add support for translating the [draft] tag behind posts.

**Was the change discussed in an issue or in the Discussions before?**

No


## PR Checklist

- [x] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have verified that the code works as described/as intended.
- [] This change adds a Social Icon which has a permissive license to use it.
- [x] This change **does not** include any CDN resources/links.
- [x] This change **does not** include any unrelated scripts such as bash and python scripts.
- [] This change updates the overridden internal templates from HUGO's repository.
