### PR TITLE
Add ORCID Social Icon

### DIFF
--- a/layouts/partials/svg.html
+++ b/layouts/partials/svg.html
@@ -378,6 +378,12 @@
         </path>
     </g>
 </svg>
+{{- else if (eq $icon_name "orcid") -}}
+<svg width="24" height="24" viewBox="0 0 256 256" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path fill-rule="evenodd" clip-rule="evenodd"
+        d="M128 256C198.7 256 256 198.7 256 128C256 57.3 198.7 0 128 0C57.3 0 0 57.3 0 128C0 198.7 57.3 256 128 256ZM70.9 186.2H86.3V127.5V79.0999H70.9V186.2ZM108.9 79.0999H150.5C190.1 79.0999 207.5 107.4 207.5 132.7C207.5 160.2 186 186.3 150.7 186.3H108.9V79.0999ZM124.3 172.4H148.8C183.7 172.4 191.7 145.9 191.7 132.7C191.7 111.2 178 93 148 93H124.3V172.4ZM78.6 66.8999C84.2 66.8999 88.7 62.2999 88.7 56.7999C88.7 51.2999 84.2 46.7 78.6 46.7C73 46.7 68.5 51.2 68.5 56.7999C68.5 62.2999 73 66.8999 78.6 66.8999Z"
+        fill="currentColor" />
+</svg>
 {{- else if (eq $icon_name "overcast") -}}
 <svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
     <path 


### PR DESCRIPTION
<!--

## READ BEFORE OPENING A PR

Thank you for contributing to hugo-PaperMod!
Please fill out the following questions to make it easier for us to review your
changes. You do not need to check all the boxes below.

**NOTE**: PaperMod does not have any external dependencies fetched from 3rd party
CDN servers. However we do have custom Head/Footer extender templates which you can use
to add those to your website.
https://github.com/adityatelange/hugo-PaperMod/wiki/FAQs#custom-head--footer

-->


**What does this PR change? What problem does it solve?**

This PR adds the ORCID social icon to the `svg.html` partial. Having the ORCID social icon may be useful for researchers using ORCID and those using this theme for their Hugo-powered site. The icon used was sourced straight from [ORCID's website and official brand assets](https://orcid.figshare.com/articles/ORCID_iD_icon_graphics/5008697), particularly the file [`ORCID-iD_icon_reversed_vector.svg`](https://orcid.figshare.com/ndownloader/files/28852014) which has been modified to use the theme's `currentColor` variable for the fill color.

The ORCID social icon in action:
![image](https://user-images.githubusercontent.com/68434444/170448025-a4c1c692-da5f-40e4-bc27-cf9b92284203.png) 
![image](https://user-images.githubusercontent.com/68434444/170450924-1b3e63bb-84e6-4ee9-bf0a-d19b52b42902.png)

<details markdown="1"><summary>Additional Information</summary>

> **Note**
> ORCID (Open Researcher and Contributor ID) is a global, not-for-profit organization and platform which assigns a nonproprietary alphanumeric code to a person to uniquely identify authors and contributors of scholarly communication or research. ORCID's website has services to look up authors and their bibliographic output (and other user-supplied pieces of information).
</details>

<!--
Describe the changes and their purpose here, as detailed as and if  needed.

Please do not add 2 unrelated changes in a single PR as it is difficult to track/revert those in future.
-->


**Was the change discussed in an issue or in the Discussions before?**

No, this change was not yet raised in an issue or in the Discussions. I was about to create a topic in Discussions but the change seems fairly simple, so I went straight for the PR.

<!--
Link issues and relevant Discussions posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->


## PR Checklist

- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have verified that the code works as described/as intended.
- [x] This change adds a Social Icon which has a permissive license to use it.
- [x] This change **does not** include any CDN resources/links.
- [x] This change **does not** include any unrelated scripts such as bash and python scripts.
- [ ] This change updates the overridden internal templates from HUGO's repository.
