### PR TITLE
Fix typo to work with site verification tags

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -23,13 +23,13 @@
     {{- with site.Params.description }}{{ . }}{{- end }}{{- end }}{{- end -}}">
 <meta name="author" content="{{ (partial "author.html" . ) }}">
 <link rel="canonical" href="{{ if .Params.canonicalURL -}} {{ trim .Params.canonicalURL " " }} {{- else -}} {{ .Permalink }} {{- end }}">
-{{- if site.Params.analytics.googlesiteVerificationTag }}
+{{- if site.Params.analytics.google.siteVerificationTag }}
 <meta name="google-site-verification" content="{{ site.Params.analytics.google.siteVerificationTag }}">
 {{- end }}
-{{- if site.Params.analytics.yandexsiteVerificationTag }}
+{{- if site.Params.analytics.yandex.siteVerificationTag }}
 <meta name="yandex-verification" content="{{ site.Params.analytics.yandex.siteVerificationTag }}">
 {{- end }}
-{{- if site.Params.analytics.bingsiteVerificationTag }}
+{{- if site.Params.analytics.bing.siteVerificationTag }}
 <meta name="msvalidate.01" content="{{ site.Params.analytics.bing.siteVerificationTag }}">
 {{- end }}
 

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -24,13 +24,13 @@
 <meta name="author" content="{{ (partial "author.html" . ) }}">
 <link rel="canonical" href="{{ if .Params.canonicalURL -}} {{ trim .Params.canonicalURL " " }} {{- else -}} {{ .Permalink }} {{- end }}">
 {{- if site.Params.analytics.googlesiteVerificationTag }}
-<meta name="google-site-verification" content="{{ site.Params.analytics.googlesiteVerificationTag }}">
+<meta name="google-site-verification" content="{{ site.Params.analytics.google.siteVerificationTag }}">
 {{- end }}
 {{- if site.Params.analytics.yandexsiteVerificationTag }}
-<meta name="yandex-verification" content="{{ site.Params.analytics.yandexsiteVerificationTag }}">
+<meta name="yandex-verification" content="{{ site.Params.analytics.yandex.siteVerificationTag }}">
 {{- end }}
 {{- if site.Params.analytics.bingsiteVerificationTag }}
-<meta name="msvalidate.01" content="{{ site.Params.analytics.bingsiteVerificationTag }}">
+<meta name="msvalidate.01" content="{{ site.Params.analytics.bing.siteVerificationTag }}">
 {{- end }}
 
 {{- /* Styles */}}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -23,14 +23,14 @@
     {{- with site.Params.description }}{{ . }}{{- end }}{{- end }}{{- end -}}">
 <meta name="author" content="{{ (partial "author.html" . ) }}">
 <link rel="canonical" href="{{ if .Params.canonicalURL -}} {{ trim .Params.canonicalURL " " }} {{- else -}} {{ .Permalink }} {{- end }}">
-{{- if site.Params.analytics.google.siteVerificationTag }}
-<meta name="google-site-verification" content="{{ site.Params.analytics.google.siteVerificationTag }}">
+{{- if site.Params.analytics.google.SiteVerificationTag }}
+<meta name="google-site-verification" content="{{ site.Params.analytics.google.SiteVerificationTag }}">
 {{- end }}
-{{- if site.Params.analytics.yandex.siteVerificationTag }}
-<meta name="yandex-verification" content="{{ site.Params.analytics.yandex.siteVerificationTag }}">
+{{- if site.Params.analytics.yandex.SiteVerificationTag }}
+<meta name="yandex-verification" content="{{ site.Params.analytics.yandex.SiteVerificationTag }}">
 {{- end }}
-{{- if site.Params.analytics.bing.siteVerificationTag }}
-<meta name="msvalidate.01" content="{{ site.Params.analytics.bing.siteVerificationTag }}">
+{{- if site.Params.analytics.bing.SiteVerificationTag }}
+<meta name="msvalidate.01" content="{{ site.Params.analytics.bing.SiteVerificationTag }}">
 {{- end }}
 
 {{- /* Styles */}}


### PR DESCRIPTION
**What does this PR change? What problem does it solve?**

Fix typo to work with site verification tags.

**Was the change discussed in an issue or in the Discussions before?**

It was originally correct code, but it has been erroneously corrected by the commit below.
575cc0ca8c4e5904c7ae77e76db812c52e5f8ed1

## PR Checklist

- [x] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have verified that the code works as described/as intended.
- [x] This change adds a Social Icon which has a permissive license to use it.
- [x] This change **does not** include any CDN resources/links.
- [x] This change **does not** include any unrelated scripts such as bash and python scripts.
- [x] This change updates the overridden internal templates from HUGO's repository.
