### PR TITLE
Fix improper image border scaling

### DIFF
--- a/assets/css/common/profile-mode.css
+++ b/assets/css/common/profile-mode.css
@@ -18,6 +18,13 @@
     display: inline-table;
     border-radius: 50%;
     pointer-events: none;
+    width: auto;
+    height: auto;
+    border-radius: 50%;
+    pointer-events: none;
+    -webkit-border-radius: 50%;
+    -moz-border-radius: 50%;
+    overflow: hidden;
 }
 
 .buttons {

--- a/assets/css/common/profile-mode.css
+++ b/assets/css/common/profile-mode.css
@@ -20,8 +20,6 @@
     pointer-events: none;
     width: auto;
     height: auto;
-    border-radius: 50%;
-    pointer-events: none;
     -webkit-border-radius: 50%;
     -moz-border-radius: 50%;
     overflow: hidden;


### PR DESCRIPTION


<!--

## READ BEFORE OPENING A PR

Thank you for contributing to hugo-PaperMod!
Please fill out the following questions to make it easier for us to review your
changes. You do not need to check all the boxes below.

**NOTE**: PaperMod does not have any external dependencies fetched from 3rd party
CDN servers. However we do have custom Head/Footer extender templates which you can use
to add those to your website.
https://github.com/adityatelange/hugo-PaperMod/wiki/FAQs#custom-head--footer

-->


Previously, the rounded image border would not scale properly with different aspect ratios as the img object changed its own aspect ratio


## PR Checklist

- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have verified that the code works as described/as intended.
- [ ] This change adds a Social Icon which has a permissive license to use it.
- [x] This change **does not** include any CDN resources/links.
- [x] This change **does not** include any unrelated scripts such as bash and python scripts.
- [ ] This change updates the overridden internal templates from HUGO's repository.
