### PR TITLE
add label.iconSVG key

### DIFF
--- a/assets/css/common/header.css
+++ b/assets/css/common/header.css
@@ -27,7 +27,7 @@
     font-weight: 700;
 }
 
-.logo a img {
+.logo a img, .logo a svg {
     display: inline;
     vertical-align: middle;
     pointer-events: none;

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -66,6 +66,8 @@
                 <img src="{{- site.Params.label.icon | absURL -}}" alt="logo" aria-label="logo"
                     height="{{- site.Params.label.iconHeight | default "30" -}}">
                 {{- end -}}
+                {{- else if hasPrefix site.Params.label.iconSVG "<svg" }}
+                    {{ site.Params.label.iconSVG | replaceRE `\s*height\s*=\s*"[\w\s]*"|\s*width\s*=\s*"[\w\s]*"` "" | replaceRE "^<svg" (printf `<svg height="%d"` site.Params.label.iconHeight) | safeHTML }}
                 {{- end -}}
                 {{- $label_text -}}
             </a>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -67,7 +67,7 @@
                     height="{{- site.Params.label.iconHeight | default "30" -}}">
                 {{- end -}}
                 {{- else if hasPrefix site.Params.label.iconSVG "<svg" }}
-                    {{ site.Params.label.iconSVG | replaceRE `\s*height\s*=\s*"[\w\s]*"|\s*width\s*=\s*"[\w\s]*"` "" | replaceRE "^<svg" (printf `<svg height="%d"` site.Params.label.iconHeight) | safeHTML }}
+                    {{ site.Params.label.iconSVG | safeHTML }}
                 {{- end -}}
                 {{- $label_text -}}
             </a>


### PR DESCRIPTION
**What does this PR change? What problem does it solve?**
This PR adds `label.iconSVG` key under site params. It can be used to embed the SVG directly for easier styling, e.g. for handling the change between dark and light mode.


**Was the change discussed in an issue or in the Discussions before?**
Closes #974.


## PR Checklist

- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have verified that the code works as described/as intended.
- [ ] This change adds a Social Icon which has a permissive license to use it.
- [x] This change **does not** include any CDN resources/links.
- [x] This change **does not** include any unrelated scripts such as bash and python scripts.
- [ ] This change updates the overridden internal templates from HUGO's repository.
