### PR TITLE
Ability to stick header to the top of the page

### DIFF
--- a/assets/css/common/header.css
+++ b/assets/css/common/header.css
@@ -1,3 +1,11 @@
+header.header-sticky {
+    position: sticky;
+    top: 0;
+    width: 100%;
+    background: var(--theme);
+    z-index: 1000;
+}
+
 .nav {
     display: flex;
     flex-wrap: wrap;

--- a/assets/css/common/header.css
+++ b/assets/css/common/header.css
@@ -1,3 +1,8 @@
+/* See: https://github.com/adityatelange/hugo-PaperMod/pull/979#issuecomment-1654974106 */
+html.header-sticky {
+    scroll-padding-top: calc(var(--header-height) * 2);
+}
+
 header.header-sticky {
     position: sticky;
     top: 0;

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -3,7 +3,7 @@
 {{- end -}}
 
 <!DOCTYPE html>
-<html lang="{{ site.Language }}" dir="{{ .Language.LanguageDirection | default "auto" }}">
+<html lang="{{ site.Language }}" dir="{{ .Language.LanguageDirection | default "auto" }}" {{ if (site.Params.stickyHeader) }}class="header-sticky"{{ end }}>
 
 <head>
     {{- partial "head.html" . }}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -39,7 +39,7 @@
 </script>
 {{- end }}
 
-<header class="header">
+<header class="header {{ if (site.Params.stickyHeader) }}header-sticky{{ end }}">
     <nav class="nav">
         <div class="logo">
             {{- $label_text := (site.Params.label.text | default site.Title) }}


### PR DESCRIPTION
**What does this PR change? What problem does it solve?**

If enabled (using `stickyHeader` param), header with top menu will be always visible regardless of scrolling.

[Live Demo](https://blog.codito.dev/).

- Works on desktop and mobile
- Supports dark/light modes
- 100% backward compatible

**Was the change discussed in an issue or in the Discussions before?**

No.

## PR Checklist

- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have verified that the code works as described/as intended.
- [ ] This change adds a Social Icon which has a permissive license to use it.
- [x] This change **does not** include any CDN resources/links.
- [x] This change **does not** include any unrelated scripts such as bash and python scripts.
- [ ] This change updates the overridden internal templates from HUGO's repository.
