### PR TITLE
add sketchfab icon

### DIFF
--- a/layouts/partials/svg.html
+++ b/layouts/partials/svg.html
@@ -487,6 +487,10 @@
     <path d="M7.728 11.725V9.032c0-1.025.824-1.85 1.849-1.85h2.815m3.88 5.093v2.693a1.845 1.845 0 0 1-1.849 1.85h-2.815"
         stroke-linecap="square" stroke-linejoin="miter" />
 </svg>
+{{- else if (eq $icon_name "sketchfab") -}}
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2000 2000" fill="currentColor">
+    <path d="m1000 0c-552.32 0-1000 447.72-1000 1000s447.68 1000 1000 1000 1000-447.72 1000-1000-447.6-1000-1000-1000zm-86.88 1595.07-431.12-248.86v-502l431.12 232.79zm76.8-636.19-510.08-270.38 510.08-294.5 510.16 294.5zm510.48 388.29-429.52 248v-516.17l429.52-232z"/>
+</svg>
 {{- else if (eq $icon_name "slack") -}}
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
     stroke-linecap="round" stroke-linejoin="round">


### PR DESCRIPTION

**What does this PR change? What problem does it solve?**

- add sketchfab icon to svgs
![image](https://user-images.githubusercontent.com/27821306/182520332-70bc0574-8660-4447-aaf1-1aeccb083f18.png)
![image](https://user-images.githubusercontent.com/27821306/182520360-4cc56ba5-04a3-4a52-8d59-a72ea50412a1.png)

## PR Checklist

- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [X] I have verified that the code works as described/as intended.
- [X] `it is from the press kit` This change adds a Social Icon which has a permissive license to use it.
- https://sketchfab.com/press
- [X] This change **does not** include any CDN resources/links.
- [X] This change **does not** include any unrelated scripts such as bash and python scripts.
- [ ] This change updates the overridden internal templates from HUGO's repository.
