### PR TITLE
feat(layouts): add iconWidth support for icon

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -43,41 +43,60 @@
     <nav class="nav">
         <div class="logo">
             {{- $label_text := (site.Params.label.text | default site.Title) }}
+            
             {{- if site.Title }}
-            <a href="{{ "" | absLangURL }}" accesskey="h" title="{{ $label_text }} (Alt + H)">
-                {{- if site.Params.label.icon }}
-                {{- $img := resources.Get site.Params.label.icon }}
-                {{- if $img }}
-                    {{- $processableFormats := (slice "jpg" "jpeg" "png" "tif" "bmp" "gif") -}}
-                    {{- if hugo.IsExtended -}}
-                        {{- $processableFormats = $processableFormats | append "webp" -}}
+                <a 
+                    accesskey="h" 
+                    href="{{ "" | absLangURL }}" 
+                    title="{{ $label_text }} (Alt + H)"
+                >
+                    {{- if site.Params.label.icon -}}
+                        {{- $img := resources.Get site.Params.label.icon -}}
+
+                        {{- if $img -}}
+                            {{- $processableFormats := (slice "jpg" "jpeg" "png" "tif" "bmp" "gif") -}}
+
+                            {{- if hugo.IsExtended -}}
+                                {{- $processableFormats = $processableFormats | append "webp" -}}
+                            {{- end -}}
+
+                            {{- $prod := (hugo.IsProduction | or (eq site.Params.env "production")) -}}
+
+                            {{- if and (in $processableFormats $img.MediaType.SubType) (eq $prod true) -}}
+                                {{- if site.Params.label.iconHeight -}}
+                                    {{- $img = $img.Resize (printf "x%s" site.Params.label.iconHeight) -}}
+
+                                {{ else -}}
+                                    {{- $img = $img.Resize "x30" -}}
+                                {{- end -}}
+                            {{- end -}}
+                            
+                            <img 
+                                alt="" 
+                                aria-label="logo"
+                                src="{{ $img.Permalink }}" 
+                                width="{{- $img.Width | default "30" -}}"
+                                height="{{- $img.Height | default "30" -}}"
+                            >
+
+                        {{- else }}
+                            <img 
+                                alt="" 
+                                aria-label="logo"
+                                src="{{- site.Params.label.icon | absURL -}}" 
+                                width="{{- site.Params.label.iconWidth | default "30" -}}"
+                                height="{{- site.Params.label.iconHeight | default "30" -}}"
+                            >
+                        {{- end -}}
+
+                    {{- else if hasPrefix site.Params.label.iconSVG "<svg" }}
+                        {{ site.Params.label.iconSVG | safeHTML }}
                     {{- end -}}
-                    {{- $prod := (hugo.IsProduction | or (eq site.Params.env "production")) }}
-                    {{- if and (in $processableFormats $img.MediaType.SubType) (eq $prod true)}}
-                        {{- if (and (site.Params.label.iconHeight) (site.Params.label.iconWidth)) }}
-                            {{- $img = $img.Resize (printf "%dx%d" site.Params.lable.iconWidth site.Params.label.iconHeight) }}
-                        {{- else if site.Params.label.iconHeight}}
-                            {{- $img = $img.Resize (printf "x%d" site.Params.label.iconHeight) }}
-                        {{ else if site.Params.label.iconWidth }}
-                            {{- $img = $img.Resize (printf "%dx" site.Params.label.iconWidth) }}
-                        {{ else }}
-                            {{- $img = $img.Resize "30x30" }}
-                        {{- end }}
-                    {{- end }}
-                    <img src="{{ $img.Permalink }}" alt="" aria-label="logo"
-                        height="{{- site.Params.label.iconHeight | default "30" -}}"
-                        width="{{- site.Params.label.iconWidth | default "30" -}}">
-                {{- else }}
-                <img src="{{- site.Params.label.icon | absURL -}}" alt="" aria-label="logo"
-                    height="{{- site.Params.label.iconHeight | default "30" -}}
-                    width="{{- site.Params.label.iconWidth | default "30" -}}">
-                {{- end -}}
-                {{- else if hasPrefix site.Params.label.iconSVG "<svg" }}
-                    {{ site.Params.label.iconSVG | safeHTML }}
-                {{- end -}}
-                {{- $label_text -}}
-            </a>
+
+                    {{- $label_text -}}
+                </a>
             {{- end }}
+
             <div class="logo-switches">
                 {{- if (not site.Params.disableThemeToggle) }}
                 <button id="theme-toggle" accesskey="t" title="(Alt + T)">

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -43,7 +43,7 @@
     <nav class="nav">
         <div class="logo">
             {{- $label_text := (site.Params.label.text | default site.Title) }}
-            
+
             {{- if site.Title }}
                 <a 
                     accesskey="h" 
@@ -64,7 +64,7 @@
 
                             {{- if and (in $processableFormats $img.MediaType.SubType) (eq $prod true) -}}
                                 {{- if site.Params.label.iconHeight -}}
-                                    {{- $img = $img.Resize (printf "x%s" site.Params.label.iconHeight) -}}
+                                    {{- $img = $img.Resize (printf "x%d" site.Params.label.iconHeight) -}}
 
                                 {{ else -}}
                                     {{- $img = $img.Resize "x30" -}}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -54,17 +54,23 @@
                     {{- end -}}
                     {{- $prod := (hugo.IsProduction | or (eq site.Params.env "production")) }}
                     {{- if and (in $processableFormats $img.MediaType.SubType) (eq $prod true)}}
-                        {{- if site.Params.label.iconHeight }}
+                        {{- if (and (site.Params.label.iconHeight) (site.Params.label.iconWidth)) }}
+                            {{- $img = $img.Resize (printf "%dx%d" site.Params.lable.iconWidth site.Params.label.iconHeight) }}
+                        {{- else if site.Params.label.iconHeight}}
                             {{- $img = $img.Resize (printf "x%d" site.Params.label.iconHeight) }}
+                        {{ else if site.Params.label.iconWidth }}
+                            {{- $img = $img.Resize (printf "%dx" site.Params.label.iconWidth) }}
                         {{ else }}
-                            {{- $img = $img.Resize "x30" }}
+                            {{- $img = $img.Resize "30x30" }}
                         {{- end }}
                     {{- end }}
                     <img src="{{ $img.Permalink }}" alt="" aria-label="logo"
-                        height="{{- site.Params.label.iconHeight | default "30" -}}">
+                        height="{{- site.Params.label.iconHeight | default "30" -}}"
+                        width="{{- site.Params.label.iconWidth | default "30" -}}">
                 {{- else }}
                 <img src="{{- site.Params.label.icon | absURL -}}" alt="" aria-label="logo"
-                    height="{{- site.Params.label.iconHeight | default "30" -}}">
+                    height="{{- site.Params.label.iconHeight | default "30" -}}
+                    width="{{- site.Params.label.iconWidth | default "30" -}}">
                 {{- end -}}
                 {{- else if hasPrefix site.Params.label.iconSVG "<svg" }}
                     {{ site.Params.label.iconSVG | safeHTML }}


### PR DESCRIPTION
<!--

## READ BEFORE OPENING A PR

Thank you for contributing to hugo-PaperMod!
Please fill out the following questions to make it easier for us to review your
changes. You do not need to check all the boxes below.

**NOTE**: PaperMod does not have any external dependencies fetched from 3rd party
CDN servers. However we do have custom Head/Footer extender templates which you can use
to add those to your website.
https://github.com/adityatelange/hugo-PaperMod/wiki/FAQs#custom-head--footer

-->


**What does this PR change? What problem does it solve?**

<!--
Describe the changes and their purpose here, as detailed as and if  needed.

Please do not add 2 unrelated changes in a single PR as it is difficult to track/revert those in future.
-->
Adds support for a new field in config's params called iconWidth.  
With iconWidth set, Lighthouse will not complain about Cumulative Shift Layouts.  
More on topic [here](https://web.dev/cls/).  


**Was the change discussed in an issue or in the Discussions before?**
No, it wasn't treated about icons specifically.  

<!--
Link issues and relevant Discussions posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->


## PR Checklist

- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [ ] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have verified that the code works as described/as intended.
- [ ] This change adds a Social Icon which has a permissive license to use it.
- [x] This change **does not** include any CDN resources/links.
- [x] This change **does not** include any unrelated scripts such as bash and python scripts.
- [ ] This change updates the overridden internal templates from HUGO's repository.
