### PR TITLE
Fastsearch params bug fix

### DIFF
--- a/assets/js/fastsearch.js
+++ b/assets/js/fastsearch.js
@@ -28,17 +28,17 @@ window.onload = function () {
                     };
                     if (params.fuseOpts) {
                         options = {
-                            isCaseSensitive: params.fuseOpts.iscasesensitive ? params.fuseOpts.iscasesensitive : false,
-                            includeScore: params.fuseOpts.includescore ? params.fuseOpts.includescore : false,
-                            includeMatches: params.fuseOpts.includematches ? params.fuseOpts.includematches : false,
-                            minMatchCharLength: params.fuseOpts.minmatchcharlength ? params.fuseOpts.minmatchcharlength : 1,
-                            shouldSort: params.fuseOpts.shouldsort ? params.fuseOpts.shouldsort : true,
-                            findAllMatches: params.fuseOpts.findallmatches ? params.fuseOpts.findallmatches : false,
-                            keys: params.fuseOpts.keys ? params.fuseOpts.keys : ['title', 'permalink', 'summary', 'content'],
-                            location: params.fuseOpts.location ? params.fuseOpts.location : 0,
-                            threshold: params.fuseOpts.threshold ? params.fuseOpts.threshold : 0.4,
-                            distance: params.fuseOpts.distance ? params.fuseOpts.distance : 100,
-                            ignoreLocation: params.fuseOpts.ignorelocation ? params.fuseOpts.ignorelocation : true
+                            isCaseSensitive:  params.fuseOpts.iscasesensitive ?? false,
+                            includeScore:  params.fuseOpts.includescore ?? false,
+                            includeMatches:  params.fuseOpts.includematches ?? false,
+                            minMatchCharLength:  params.fuseOpts.minmatchcharlength ?? 1,
+                            shouldSort:  params.fuseOpts.shouldsort ?? true,
+                            findAllMatches:  params.fuseOpts.findallmatches ?? false,
+                            keys:  params.fuseOpts.keys ?? ['title', 'permalink', 'summary', 'content'],
+                            location:  params.fuseOpts.location ?? 0,
+                            threshold:  params.fuseOpts.threshold ?? 0.4,
+                            distance:  params.fuseOpts.distance ?? 100,
+                            ignoreLocation:  params.fuseOpts.ignorelocation ?? true
                         }
                     }
                     fuse = new Fuse(data, options); // build the index from the json file

--- a/assets/js/fastsearch.js
+++ b/assets/js/fastsearch.js
@@ -28,17 +28,17 @@ window.onload = function () {
                     };
                     if (params.fuseOpts) {
                         options = {
-                            isCaseSensitive:  params.fuseOpts.iscasesensitive ?? false,
-                            includeScore:  params.fuseOpts.includescore ?? false,
-                            includeMatches:  params.fuseOpts.includematches ?? false,
-                            minMatchCharLength:  params.fuseOpts.minmatchcharlength ?? 1,
-                            shouldSort:  params.fuseOpts.shouldsort ?? true,
-                            findAllMatches:  params.fuseOpts.findallmatches ?? false,
-                            keys:  params.fuseOpts.keys ?? ['title', 'permalink', 'summary', 'content'],
-                            location:  params.fuseOpts.location ?? 0,
-                            threshold:  params.fuseOpts.threshold ?? 0.4,
-                            distance:  params.fuseOpts.distance ?? 100,
-                            ignoreLocation:  params.fuseOpts.ignorelocation ?? true
+                            isCaseSensitive: params.fuseOpts.iscasesensitive ?? false,
+                            includeScore: params.fuseOpts.includescore ?? false,
+                            includeMatches: params.fuseOpts.includematches ?? false,
+                            minMatchCharLength: params.fuseOpts.minmatchcharlength ?? 1,
+                            shouldSort: params.fuseOpts.shouldsort ?? true,
+                            findAllMatches: params.fuseOpts.findallmatches ?? false,
+                            keys: params.fuseOpts.keys ?? ['title', 'permalink', 'summary', 'content'],
+                            location: params.fuseOpts.location ?? 0,
+                            threshold: params.fuseOpts.threshold ?? 0.4,
+                            distance: params.fuseOpts.distance ?? 100,
+                            ignoreLocation: params.fuseOpts.ignorelocation ?? true
                         }
                     }
                     fuse = new Fuse(data, options); // build the index from the json file


### PR DESCRIPTION
i.e. if params.fuseOpts.threshold is 0.0 or params.fuseOpts.ignorelocation is false, the default values of 0.4 and true will still be used.

<!--

## READ BEFORE OPENING A PR

Thank you for contributing to hugo-PaperMod!
Please fill out the following questions to make it easier for us to review your
changes. You do not need to check all the boxes below.

**NOTE**: PaperMod does not have any external dependencies fetched from 3rd party
CDN servers. However we do have custom Head/Footer extender templates which you can use
to add those to your website.
https://github.com/adityatelange/hugo-PaperMod/wiki/FAQs#custom-head--footer

-->


**What does this PR change? What problem does it solve?**

<!--
Describe the changes and their purpose here, as detailed as and if  needed.

Please do not add 2 unrelated changes in a single PR as it is difficult to track/revert those in future.
-->


Changing the code for grabbing the fuse parameters to use the nullish coalescing operator instead of doing boolean coercion, since boolean coercion prevents certain values from being propagated. 
 
I.e. params.fuseOpts.ignorelocation ? params.fuseOpts.ignorelocation: true will always be true. I don't think I have seen this discussed, and just happened to find the bug while working with the theme :)


**Was the change discussed in an issue or in the Discussions before?**

<!--
Link issues and relevant Discussions posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->


## PR Checklist

- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [X] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [X] I have verified that the code works as described/as intended.
- [ ] This change adds a Social Icon which has a permissive license to use it.
- [X] This change **does not** include any CDN resources/links.
- [X] This change **does not** include any unrelated scripts such as bash and python scripts.
- [ ] This change updates the overridden internal templates from HUGO's repository.
