### PR TITLE
Show related posts

### DIFF
--- a/assets/css/common/post-single.css
+++ b/assets/css/common/post-single.css
@@ -295,6 +295,18 @@
     margin-top: 56px;
 }
 
+.post-footer h3 {
+  margin: 2em 0 1.2em;
+}
+
+.post-footer .related ul  {
+    padding-inline-start: 20px;
+}
+
+.post-footer .related a:hover {
+  box-shadow: 0 1px;
+}
+
 .post-tags li {
     display: inline-block;
     margin-inline-end: 3px;

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -31,3 +31,6 @@
 
 - id: code_copied
   translation: "copied!"
+
+- id: related
+  translation: "See also"

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -33,4 +33,4 @@
   translation: "copied!"
 
 - id: related
-  translation: "See also"
+  translation: "Related posts"

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -31,3 +31,6 @@
 
 - id: code_copied
   translation: "Copié !"
+
+- id: related
+  translation: "Voir aussi"

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -33,4 +33,4 @@
   translation: "Copié !"
 
 - id: related
-  translation: "Voir aussi"
+  translation: "Sur le même sujet"

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -36,6 +36,12 @@
   {{- end }}
 
   <footer class="post-footer">
+
+    {{/*  Show related posts  */}}
+    {{- if (.Param "ShowRelatedContent") }}
+      {{- partial "related.html" . }}
+    {{- end }}
+
     {{- $tags := .Language.Params.Taxonomies.tag | default "tags" }}
     <ul class="post-tags">
       {{- range ($.GetTerms $tags) }}

--- a/layouts/partials/related.html
+++ b/layouts/partials/related.html
@@ -1,0 +1,13 @@
+{{ $related := first 5 (where (where .Site.Pages ".Params.tags" "intersect" .Params.tags) "Permalink" "!=" .Permalink) }}
+{{ with $related }}
+  <div class="related">
+    <h3 class="see-also">{{- i18n "related" -}}</h3>
+    <ul>
+      {{ range . }}
+        <li>
+          <a href="{{ .RelPermalink }}">{{ .Title }}</a>
+        </li>
+      {{ end }}
+    </ul>
+  </div>
+{{ end }}


### PR DESCRIPTION
**What does this PR change? What problem does it solve?**

Related posts are optionally displayed at the bottom of `single.html`

Enable with `ShowRelatedContent: true` in the config file

**Was the change discussed in an issue or in the Discussions before?**

Yes, see #762 

## PR Checklist

- [x] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have verified that the code works as described/as intended.
- [x] This change **does not** include any CDN resources/links.
- [x] This change **does not** include any unrelated scripts such as bash and python scripts.

## What's left to do?

- [x] update exampleSite
- [ ] update the wiki

(publishing now to avoid duplicate content from another contributor)