### PR TITLE
Paginav: hide post name on small devices

### DIFF
--- a/assets/css/common/post-single.css
+++ b/assets/css/common/post-single.css
@@ -391,6 +391,16 @@ h6:hover .anchor {
     text-align: left;
 }
 
+.paginav .name {
+  display: none;
+}
+
+@media screen and (min-width: 540px) {
+  .paginav .name {
+    display: block;
+  }
+}
+
 h1>a>svg {
     display: inline;
 }

--- a/layouts/partials/post_nav_links.html
+++ b/layouts/partials/post_nav_links.html
@@ -5,14 +5,14 @@
   <a class="prev" href="{{ .Permalink }}">
     <span class="title">« {{ i18n "prev_page" }}</span>
     <br>
-    <span>{{- .Name -}}</span>
+    <span class="name">{{- .Name -}}</span>
   </a>
   {{- end }}
   {{- with $pages.Prev . }}
   <a class="next" href="{{ .Permalink }}">
     <span class="title">{{ i18n "next_page" }} »</span>
     <br>
-    <span>{{- .Name -}}</span>
+    <span class="name">{{- .Name -}}</span>
   </a>
   {{- end }}
 </nav>


### PR DESCRIPTION
**What does this PR change? What problem does it solve?**
Long titles are not displayed properly on small devices:

![2022-09-23_19-29](https://user-images.githubusercontent.com/77257518/192024241-e9ca31c8-cd43-4ab3-acbb-fc582db963d4.png)


This PR proposes to hide the post names until reaching a comfortable resolution

## PR Checklist

- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have verified that the code works as described/as intended.
- [x] This change **does not** include any CDN resources/links.
- [x] This change **does not** include any unrelated scripts such as bash and python scripts.
