### PR TITLE
add localization of date-times for other locales

### DIFF
--- a/assets/js/datelocale.ts
+++ b/assets/js/datelocale.ts
@@ -1,0 +1,21 @@
+function formatDate(date: string | null) {
+  if (!date) return date;
+  return new Intl.DateTimeFormat(process.env.lang_code, {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+    // hour:'2-digit',
+    // minute: '2-digit',
+  }).format(new Date(date));
+}
+
+if ('Intl' in window) {
+  window.addEventListener('load', () => {
+    for(const span of [...document.querySelectorAll('.localizable-date')]) {
+      var persianDate = formatDate(span.getAttribute('title'));
+      if (persianDate) {
+        span.innerHTML = persianDate;
+      }
+    }
+  });
+}

--- a/assets/js/datelocale.ts
+++ b/assets/js/datelocale.ts
@@ -4,17 +4,15 @@ function formatDate(date: string | null) {
     year: 'numeric',
     month: 'long',
     day: 'numeric',
-    // hour:'2-digit',
-    // minute: '2-digit',
   }).format(new Date(date));
 }
 
 if ('Intl' in window) {
   window.addEventListener('load', () => {
     for(const span of [...document.querySelectorAll('.localizable-date')]) {
-      var persianDate = formatDate(span.getAttribute('title'));
-      if (persianDate) {
-        span.innerHTML = persianDate;
+      const localizedDate = formatDate(span.getAttribute('title'));
+      if (localizedDate) {
+        span.innerHTML = localizedDate;
       }
     }
   });

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -89,6 +89,19 @@
 {{- end }}
 {{- end -}}
 
+{{- /* localize dates */}}
+{{- if (not site.Params.disableDateLocalization) }}
+{{ $defines := dict "process.env.lang_code" (printf `"%s"` site.LanguageCode) }}
+{{ $opts := dict "targetPath" "datelocale.ts" "defines" $defines }}
+{{- if not site.Params.assets.disableFingerprinting }}
+{{ $built := resources.Get "js/datelocale.ts" | js.Build $opts | fingerprint }}
+<script defer crossorigin="anonymous" src="{{ $built.Permalink }}" integrity="{{ $built.Data.Integrity }}"></script>
+{{- else }}
+{{ $built := resources.Get "js/datelocale.js" | js.Build $opts }}
+<script defer crossorigin="anonymous" src="{{ $built.Permalink }}"></script>
+{{- end }}
+{{- end }}
+
 {{- /* Highlight.js */}}
 {{- $isHLJSdisabled := (site.Params.assets.disableHLJS | default .Params.disableHLJS ) }}
 {{- if (and (eq .Kind "page") (ne .Layout "archives") (ne .Layout "search") (not $isHLJSdisabled)) }}

--- a/layouts/partials/post_meta.html
+++ b/layouts/partials/post_meta.html
@@ -1,7 +1,7 @@
 {{- $scratch := newScratch }}
 
 {{- if not .Date.IsZero -}}
-{{- $scratch.Add "meta" (slice (printf "<span title='%s'>%s</span>" (.Date) (.Date | time.Format (default "January 2, 2006" site.Params.DateFormat)))) }}
+{{- $scratch.Add "meta" (slice (printf "<span class='localizable-date' title='%s'>%s</span>" (.Date) (.Date | time.Format (default "January 2, 2006" site.Params.DateFormat)))) }}
 {{- end }}
 
 {{- if (.Param "ShowReadingTime") -}}


### PR DESCRIPTION
**What does this PR change? What problem does it solve?**

It adds localized date-times for languages and locales other than en-us. for example when language is `fa` and languageCode is 'fa-IR', all post date-times are rendered in persian calendar, using javascript intl.

**Was the change discussed in an issue or in the Discussions before?**

nope, I don't think so.


## PR Checklist

- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have verified that the code works as described/as intended.
- [ ] This change adds a Social Icon which has a permissive license to use it.
- [x] This change **does not** include any CDN resources/links.
- [x] This change **does not** include any unrelated scripts such as bash and python scripts.
- [ ] This change updates the overridden internal templates from HUGO's repository.
