### PR TITLE
Add margin top to certain single elements surrounded by code blocks for consistency

### DIFF
--- a/assets/css/common/post-single.css
+++ b/assets/css/common/post-single.css
@@ -191,6 +191,13 @@
     margin-bottom: 0;
 }
 
+.post-content .highlight + ol,
+.post-content .highlight + p,
+.post-content .highlight + figure,
+.post-content .highlight + ul {
+    margin-top: var(--content-gap)
+}
+
 .post-content code {
     margin: auto 4px;
     padding: 4px 6px;


### PR DESCRIPTION
### What does this PR change? What problem does it solve?

Take this structure:

```html
<div .highlight>
<p>

<div .highlight>
```

The current post-single CSS adds margin to the bottom of the paragraph and that's it. This works great when the previous element also got the same amount of bottom margin, however code blocks do not! The end result looks similar to the figure above.

This commit fixes this adding top margin to elements that come immediately after a code block (they have the .highlight class). The amount of top margin added is the same they already get on the bottom.

**Before** (notice that elements between the codeblocks appear closer to the previous code block than the next[^1])

![image](https://user-images.githubusercontent.com/63936253/211215486-fb629952-b56e-4a32-832a-f994bc4056c3.png)

**After**

![image](https://user-images.githubusercontent.com/63936253/211215495-734b7f77-9ddf-4eb2-83d8-55c0f27bb388.png)

I left definition lists alone because they lack any margin at all so adding some margin top would be inconsistent. 

### Was the change discussed in an issue or in the Discussions before?

Nope. My apologies if this is bad form on my part!

### PR Checklist

- [x] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-). **n/a**
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have verified that the code works as described/as intended.
- [x] This change adds a Social Icon which has a permissive license to use it. **n/a**
- [x] This change **does not** include any CDN resources/links. **n/a**
- [x] This change **does not** include any unrelated scripts such as bash and python scripts. **n/a**
- [x] This change updates the overridden internal templates from HUGO's repository. **n/a**

[^1]: Except for ordered lists, my user agent spreadsheets apparently already "fixes" this problem adding enough margin top.