### PR TITLE
Add [future]/[expired] to future/expired posts

### DIFF
--- a/assets/css/common/post-entry.css
+++ b/assets/css/common/post-entry.css
@@ -81,7 +81,9 @@
 }
 
 .entry-cover,
-.entry-isdraft {
+.entry-isdraft,
+.entry-isfuture,
+.entry-isexpired {
     font-size: 14px;
     color: var(--secondary);
 }

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -68,6 +68,8 @@
     <h2>
       {{- .Title }}
       {{- if .Draft }}<sup><span class="entry-isdraft">&nbsp;&nbsp;[draft]</span></sup>{{- end }}
+      {{- if and (not .Date.IsZero) (gt (time .Date) now) }}<sup><span class="entry-isfuture">&nbsp;&nbsp;[future]</span></sup>{{- end }}
+      {{- if and (not .ExpiryDate.IsZero) (gt now (time .ExpiryDate)) }}<sup><span class="entry-isexpired">&nbsp;&nbsp;[expired]</span></sup>{{- end }}
     </h2>
   </header>
   {{- if (ne (.Param "hideSummary") true) }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -6,6 +6,8 @@
     <h1 class="post-title">
       {{ .Title }}
       {{- if .Draft }}<sup><span class="entry-isdraft">&nbsp;&nbsp;[draft]</span></sup>{{- end }}
+      {{- if and (not .Date.IsZero) (gt (time .Date) now) }}<sup><span class="entry-isfuture">&nbsp;&nbsp;[future]</span></sup>{{- end }}
+      {{- if and (not .ExpiryDate.IsZero) (gt now (time .ExpiryDate)) }}<sup><span class="entry-isexpired">&nbsp;&nbsp;[expired]</span></sup>{{- end }}
     </h1>
     {{- if .Description }}
     <div class="post-description">


### PR DESCRIPTION
<!--

## READ BEFORE OPENING A PR

Thank you for contributing to hugo-PaperMod!
Please fill out the following questions to make it easier for us to review your
changes. You do not need to check all the boxes below.

**NOTE**: PaperMod does not have any external dependencies fetched from 3rd party
CDN servers. However we do have custom Head/Footer extender templates which you can use
to add those to your website.
https://github.com/adityatelange/hugo-PaperMod/wiki/FAQs#custom-head--footer

-->


**What does this PR change? What problem does it solve?**

<!--
Describe the changes and their purpose here, as detailed as and if  needed.

Please do not add 2 unrelated changes in a single PR as it is difficult to track/revert those in future.
-->

This PR adds `[future]` and `[expired]` labels to the post title in listings/single entry view, similarly to the existing `[draft]` logic.

Those labels will show up next to affected posts, if they are rendered (`hugo -F -E` was used). Helps to visually distinguish these post types during editing, just like `[draft]` does.

Example:

![Screenshot_20230122_134801_Firefox](https://user-images.githubusercontent.com/83657/213916608-ac628ebf-942a-4072-b2c8-17831f11b30e.jpg)

Logic is

- future: Date is set and after now
- expired: ExpiryDate is set and before now

If there's any way to get this determined directly by Hugo I'd love to use that instead, however I couldn't find something as convenient as `.Draft` for either future or expired state (still a very Hugo newbie).

**Was the change discussed in an issue or in the Discussions before?**

<!--
Link issues and relevant Discussions posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Closes #1119


## PR Checklist

- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have verified that the code works as described/as intended.
- [ ] This change adds a Social Icon which has a permissive license to use it.
- [x] This change **does not** include any CDN resources/links.
- [x] This change **does not** include any unrelated scripts such as bash and python scripts.
- [ ] This change updates the overridden internal templates from HUGO's repository.
