### PR TITLE
Cleanup favicons

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -103,11 +103,11 @@
 {{- end }}
 
 {{- /* Favicons */}}
-<link rel="icon" href="{{ site.Params.assets.favicon | default "favicon.ico" | absURL }}">
-<link rel="icon" type="image/png" sizes="16x16" href="{{ site.Params.assets.favicon16x16 | default "favicon-16x16.png" | absURL }}">
-<link rel="icon" type="image/png" sizes="32x32" href="{{ site.Params.assets.favicon32x32 | default "favicon-32x32.png" | absURL }}">
-<link rel="apple-touch-icon" href="{{ site.Params.assets.apple_touch_icon | default "apple-touch-icon.png" | absURL }}">
-<link rel="mask-icon" href="{{ site.Params.assets.safari_pinned_tab | default "safari-pinned-tab.svg" | absURL }}">
+<link rel="icon" href="{{ site.Params.assets.favicon | default "favicon.ico" | absURL }}" sizes="any"><!-- 32×32 -->
+<link rel="icon" href="{{ site.Params.assets.icon | default "icon.svg" | absURL }}" type="image/svg+xml">
+<link rel="apple-touch-icon" href="{{ site.Params.assets.apple_touch_icon | default "apple-touch-icon.png" | absURL }}"><!-- 180×180 -->
+<link rel="manifest" href="{{ site.Params.assets.webmanifest | default "site.webmanifest" | absURL }}"><!-- 192x192 + 512x512 -->
+{{- /* Colors */}}
 <meta name="theme-color" content="{{ site.Params.assets.theme_color | default "#2e2e33" }}">
 <meta name="msapplication-TileColor" content="{{ site.Params.assets.msapplication_TileColor | default "#2e2e33" }}">
 

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -103,7 +103,7 @@
 {{- end }}
 
 {{- /* Favicons */}}
-<link rel="icon" href="{{ site.Params.assets.favicon | default "favicon.ico" | absURL }}" sizes="any"><!-- 32×32 -->
+<link rel="icon" href="{{ site.Params.assets.favicon | default "favicon.ico" | absURL }}" sizes="any"><!-- 48×48 -->
 <link rel="icon" href="{{ site.Params.assets.icon | default "icon.svg" | absURL }}" type="image/svg+xml">
 <link rel="apple-touch-icon" href="{{ site.Params.assets.apple_touch_icon | default "apple-touch-icon.png" | absURL }}"><!-- 180×180 -->
 <link rel="manifest" href="{{ site.Params.assets.webmanifest | default "site.webmanifest" | absURL }}"><!-- 192x192 + 512x512 -->


### PR DESCRIPTION
**What does this PR change? What problem does it solve?**

Hello @adityatelange 

Just a small contribution to modernise / cleanup favicons for PaperMod.

I have followed this article ["How to Favicon in 2022: Six files that fit most needs"](https://evilmartians.com/chronicles/how-to-favicon-in-2021-six-files-that-fit-most-needs) as the best practice. Long story short, all we need are just 2 images to cater for desktop and 3 resizes to cater for mobile (Apple and Android).

Desktop:

1. Modern (vector) icon in SVG format
2. Legacy "favicon.ico" in ICO format (a "pack" of three images 16x16, 32x32 and 48x48)

Mobile:

1. Apple devices: "apple-touch-icon" image in PNG format (180×180)
2. Android devices: two images in PNG format (192x192 + 512x512). Images should be served via site.webmanifest file. Same file can also be used to turn the whole site into a Progressive Web App (PWA)

All raster images (ICO and PNG) can be created as resizes of the (vector) SVG icon. Once you have the SVG icon, the rest is very easy.

Image optimisation:

- SVG: run `npx svgo --multipass icon.svg`
- PNG: via https://squoosh.app

There is no need to create additional resizes for Windows tiles. A static browserconfig.xml file referencing 512x512 icon will do just fine. Also, there is no need to cater for "Safari Pinned Icon" as even Apple does not care about it anymore.

Sample icons (full set):

- https://www.geeqla.com/icon.svg
- https://www.geeqla.com/favicon.ico
- https://www.geeqla.com/apple-touch-icon.png
- https://www.geeqla.com/icon-192.png
- https://www.geeqla.com/icon-512.png
- https://www.geeqla.com/site.webmanifest
- https://www.geeqla.com/browserconfig.xml

Default files can be changed via variables in config under `Params`:

- site.Params.assets.icon
- site.Params.assets.favicon
- site.Params.assets.apple_touch_icon
- site.Params.assets.webmanifest

**Note:** it is not a good practice to rename some favicon files. We should consider dropping some (or all) these variables.

Validation via "favicon checker" (please compare):

- https://realfavicongenerator.net/favicon_checker?protocol=https&site=www.geeqla.com
- https://realfavicongenerator.net/favicon_checker?protocol=https&site=adityatelange.in

**Was the change discussed in an issue or in the Discussions before?**

No.

## PR Checklist

- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have verified that the code works as described/as intended.
- [ ] This change adds a Social Icon which has a permissive license to use it.
- [x] This change **does not** include any CDN resources/links.
- [x] This change **does not** include any unrelated scripts such as bash and python scripts.
- [ ] This change updates the overridden internal templates from HUGO's repository.
