### PR TITLE
added LubimyCzytac.pl icon

### DIFF
--- a/layouts/partials/svg.html
+++ b/layouts/partials/svg.html
@@ -640,6 +640,12 @@
     </path>
     <polygon points="9.75 15.02 15.5 11.75 9.75 8.48 9.75 15.02"></polygon>
 </svg>
+{{- else if (eq $icon_name "lubimyczytac") -}}
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 41.4 36" fill="currentColor" stroke="none" stroke-width="1">
+    <path
+        d="M40.1,18.1l0.2-0.1l0-2.2l0.1-4.9l0-4.7L29,1.3c-1.9-0.8-4.1-0.9-6.1-0.2L3.2,8.4C1.3,9,0,10.8,0,13.2 c0,1,0.2,2.1,0.7,3l0,3.4l0,5v2l1.7,0.9L16,34.6l1.3,0.7l1.4-0.6l18.3-7c2.4-0.9,4.1-3.6,4.1-6.3C41.1,20.1,40.7,19,40.1,18.1z M34.7,16.6l-2.3,0.9l-14.9,5.4l-4.3-2.2l-7.7-4.1l-1-0.5c-0.7-0.8-1.2-1.9-1.2-2.9s0.5-1.7,1.3-1.7c0.2,0,0.5,0,0.8,0.2l12.2,6.2 l19.7-7l-0.1,4.9l-1.6,0.6C35.2,16.4,34.9,16.5,34.7,16.6z M35.8,24.6l-18.3,7.1L4,24.5l0-4.8l7.7,3.9l5.9,3.1l16-6.2l2.7-1h0.2 c0.8,0,1.4,0.7,1.4,1.9C37.8,22.7,37,24.2,35.8,24.6z">
+    </path>
+</svg>
 {{- else if $icon_name -}}
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
     stroke-linecap="round" stroke-linejoin="round">


### PR DESCRIPTION
**What does this PR change? What problem does it solve?**
I have added lubimyczytac.pl icon
I asked and received svg icon from marketing team of lubimyczytac.pl marketing@lubimyczytac.pl 

**Was the change discussed in an issue or in the Discussions before?**
no

## PR Checklist

- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [ ] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have verified that the code works as described/as intended.
- [x] This change adds a Social Icon which has a permissive license to use it.
- [x] This change **does not** include any CDN resources/links.
- [x] This change **does not** include any unrelated scripts such as bash and python scripts.
- [ ] This change updates the overridden internal templates from HUGO's repository.
