### PR TITLE
Add RSS icon to archive pages

### DIFF
--- a/layouts/_default/archives.html
+++ b/layouts/_default/archives.html
@@ -1,7 +1,19 @@
 {{- define "main" }}
 
 <header class="page-header">
-  <h1>{{ .Title }}</h1>
+  <h1>
+        {{ .Title }}
+        {{- if and (or (eq .Kind `term`) (eq .Kind `section`)) (.Param "ShowRssButtonInSectionTermList") }}
+        <a href="index.xml" title="RSS" aria-label="RSS">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+            stroke-linecap="round" stroke-linejoin="round" height="23">
+            <path d="M4 11a9 9 0 0 1 9 9" />
+            <path d="M4 4a16 16 0 0 1 16 16" />
+            <circle cx="5" cy="19" r="1" />
+        </svg>
+        </a>
+        {{- end }}
+    </h1>
   {{- if .Description }}
   <div class="post-description">
     {{ .Description }}


### PR DESCRIPTION
<!--

## READ BEFORE OPENING A PR

Thank you for contributing to hugo-PaperMod!
Please fill out the following questions to make it easier for us to review your
changes. You do not need to check all the boxes below.

**NOTE**: PaperMod does not have any external dependencies fetched from 3rd party
CDN servers. However we do have custom Head/Footer extender templates which you can use
to add those to your website.
https://github.com/adityatelange/hugo-PaperMod/wiki/FAQs#custom-head--footer

-->


**What does this PR change? What problem does it solve?**

If the setting “ShowRssButtonInSectionTermList” is true, I think it
makes sense to also show the RSS icon by the title in archive pages, as
we do for other article lists.

Tested on [my website](https://cj.rs/blog/):
![image](https://user-images.githubusercontent.com/7347374/218261309-d0bdfc3a-9b20-4a89-b5e7-930ee3e8dd14.png)


This reuses the code of `layouts/_default/list.html`.


**Was the change discussed in an issue or in the Discussions before?**

Not that I’m aware.


## PR Checklist

- [X] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [X] I have verified that the code works as described/as intended.
- [X] This change **does not** include any CDN resources/links.
- [X] This change **does not** include any unrelated scripts such as bash and python scripts.
