### PR TITLE
feat: new language switch behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 -   Social Icons (home-info and profile-mode)
 -   Social-Media Share buttons on posts.
 -   Menu location indicator.
--   Multilingual support. (with language selector)
+-   Multilingual support (with improved language selector)
 -   Taxonomies
 -   Cover image for each post (with Responsive image support).
 -   Light/Dark theme (automatic theme switch a/c to browser theme and theme-switch button).

--- a/layouts/_default/search.html
+++ b/layouts/_default/search.html
@@ -13,10 +13,10 @@
         {{ .Description }}
     </div>
     {{- end }}
-    {{- if not (.Param "hideMeta") }}
-    <div class="post-meta">
-        {{- partial "translation_list.html" . -}}
-    </div>
+    {{- if and (.Param "showTranslationListInPosts") (not (.Param "hideMeta")) }}
+        <div class="post-meta">
+            {{- partial "translation_list.html" . -}}
+        </div>
     {{- end }}
 </header>
 

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -15,7 +15,9 @@
     {{- if not (.Param "hideMeta") }}
     <div class="post-meta">
       {{- partial "post_meta.html" . -}}
-      {{- partial "translation_list.html" . -}}
+      {{- if .Param "showTranslationListInPosts" }}
+        {{- partial "translation_list.html" . -}}
+      {{- end }}
       {{- partial "edit_post.html" . -}}
       {{- partial "post_canonical.html" . -}}
     </div>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -96,27 +96,42 @@
                 </button>
                 {{- end }}
 
-                {{- $lang := .Lang}}
-                {{- $separator := or $label_text (not site.Params.disableThemeToggle)}}
-                {{- with site.Home.AllTranslations }}
-                <ul class="lang-switch">
-                    {{- if $separator }}<li>|</li>{{ end }}
-                    {{- range . -}}
-                    {{- if ne $lang .Lang }}
-                    <li>
-                        <a href="{{- .Permalink -}}" title="{{ .Language.Params.languageAltTitle | default (.Language.LanguageName | emojify) | default (.Lang | title) }}"
-                            aria-label="{{ .Language.LanguageName | default (.Lang | title) }}">
-                            {{- if (and site.Params.displayFullLangName (.Language.LanguageName)) }}
-                            {{- .Language.LanguageName | emojify -}}
-                            {{- else }}
-                            {{- .Lang | title -}}
-                            {{- end -}}
-                        </a>
-                    </li>
-                    {{- end -}}
-                    {{- end}}
-                </ul>
-                {{- end }}
+                {{/* LANGUAGE SELECTOR */}}
+                {{ if .Site.IsMultiLingual }}
+                    {{/* set vars with page data */}}
+                    {{ $currentLang := .Lang }}
+                    {{ $allTranslations := .Translations }}
+
+                    {{ $separator := or $label_text (not site.Params.disableThemeToggle)}}
+
+                    <ul class="lang-switch">
+                        {{ if $separator }}<li>|</li>{{ end }}
+                        {{ range $anySiteLang := .Site.Home.AllTranslations }}
+
+                            {{/* code here can only access page-related data via vars set above */}}
+                            {{ if ne $currentLang $anySiteLang.Lang }}
+                                {{ $translationLink := .Permalink }}
+                                {{ range $translation := $allTranslations }}
+                                    {{ if eq $anySiteLang.Lang $translation.Lang }}
+                                        {{ $translationLink = $translation.Permalink }}
+                                    {{ end }}
+                                {{ end }}
+
+                                <li>
+                                    <a href="{{ $translationLink }}"
+                                    title="{{ .Language.Params.languageAltTitle | default (.Language.LanguageName ) | default (.Lang | upper) }}"
+                                    aria-label="{{ .Language.LanguageName | default (.Lang | upper) }}">
+                                        {{ if site.Params.DisplayFullLangName }}
+                                            {{ .Language.LanguageName }}
+                                        {{ else }}
+                                            {{ .Lang | upper }}
+                                        {{ end }}
+                                    </a>
+                                </li>
+                            {{ end }}
+                        {{ end }}
+                    </ul>
+                {{ end }}
             </div>
         </div>
         {{- $currentPage := . }}


### PR DESCRIPTION
**What does this PR change? What problem does it solve?**

Currently, the language switch _always_ links to each language's main page and not any possible translation of the page. This PR changes the way the language switch works significantly. The language switch still lists all languages available according to their "weight", but if there is a translation, then that translation will be linked, otherwise that language's main page as before. As this replaces the need for the translation list in posts, translation lists in posts have been made optional with a new boolean parameter "showTranslationListInPosts". I have tested the changes extensively and with different parameters and language settings.


**Was the change discussed in an issue or in the Discussions before?**

Closes #1065 


## PR Checklist

- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have verified that the code works as described/as intended.
- [ ] This change adds a Social Icon which has a permissive license to use it.
- [x] This change **does not** include any CDN resources/links.
- [x] This change **does not** include any unrelated scripts such as bash and python scripts.
- [ ] This change updates the overridden internal templates from HUGO's repository.
