### PR TITLE
Add `hiddenPage` mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,27 +26,27 @@
 
 ## Features/Mods 💥
 
--   Uses Hugo's asset generator with pipelining, fingerprinting, bundling and minification by default.
+-   Uses Hugo's asset generator with pipelining, fingerprinting, bundling and minification by default
 -   3 Modes:
-    -   [Regular Mode.](https://github.com/adityatelange/hugo-PaperMod/wiki/Features#regular-mode-default-mode)
-    -   [Home-Info Mode.](https://github.com/adityatelange/hugo-PaperMod/wiki/Features#home-info-mode)
-    -   [Profile Mode.](https://github.com/adityatelange/hugo-PaperMod/wiki/Features#profile-mode)
--   Table of Content Generation (newer implementation).
--   Archive of posts.
+    -   [Regular Mode](https://github.com/adityatelange/hugo-PaperMod/wiki/Features#regular-mode-default-mode)
+    -   [Home-Info Mode](https://github.com/adityatelange/hugo-PaperMod/wiki/Features#home-info-mode)
+    -   [Profile Mode](https://github.com/adityatelange/hugo-PaperMod/wiki/Features#profile-mode)
+-   Table of Content Generation (newer implementation)
+-   Archive of posts
 -   Social Icons (home-info and profile-mode)
--   Social-Media Share buttons on posts.
--   Menu location indicator.
--   Multilingual support. (with language selector)
+-   Social-Media Share buttons on posts
+-   Menu location indicator
+-   Multilingual support (with language selector)
 -   Taxonomies
--   Cover image for each post (with Responsive image support).
--   Light/Dark theme (automatic theme switch a/c to browser theme and theme-switch button).
--   SEO Friendly.
--   Multiple Author support.
+-   Cover image for each post (with Responsive image support)
+-   Light/Dark theme (automatic theme switch a/c to browser theme and theme-switch button)
+-   SEO Friendly
+-   Multiple Author support
 -   Search Page with Fuse.js
 -   Other Posts suggestion below a post
 -   Breadcrumb Navigation
 -   Code Block Copy buttons
--   No webpack, nodejs and other dependencies are required to edit the theme.
+-   No webpack, nodejs and other dependencies are required to edit the theme
 
 Read Wiki For More Details => **[PaperMod - Features](https://github.com/adityatelange/hugo-PaperMod/wiki/Features)**
 

--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -1,0 +1,1 @@
+<a href="{{ .Destination | safeURL }}" {{ with .Title }}title="{{ . }}"{{ end }} {{ if strings.HasPrefix .Destination "http" | and (eq .Page.Params.hiddenPage true) }}target="_blank" rel="nofollow noopener noreferrer"{{ end }}>{{ .Text | safeHTML }}</a>

--- a/layouts/_default/archives.html
+++ b/layouts/_default/archives.html
@@ -9,7 +9,7 @@
   {{- end }}
 </header>
 
-{{- $pages := where (where site.RegularPages "Type" "in" site.Params.mainSections) "Params.hiddenPage" "!=" "true" }}
+{{- $pages := where (where site.RegularPages "Type" "in" site.Params.mainSections) "Params.hiddenPage" "!=" true }}
 
 {{- if site.Params.ShowAllPagesInArchive }}
 {{- $pages = site.RegularPages }}

--- a/layouts/_default/archives.html
+++ b/layouts/_default/archives.html
@@ -9,7 +9,7 @@
   {{- end }}
 </header>
 
-{{- $pages := where site.RegularPages "Type" "in" site.Params.mainSections }}
+{{- $pages := where (where site.RegularPages "Type" "in" site.Params.mainSections) "Params.hiddenPage" "!=" "true" }}
 
 {{- if site.Params.ShowAllPagesInArchive }}
 {{- $pages = site.RegularPages }}

--- a/layouts/_default/index.json
+++ b/layouts/_default/index.json
@@ -1,6 +1,6 @@
 {{- $.Scratch.Add "index" slice -}}
 {{- range site.RegularPages -}}
-    {{- if and (not .Params.searchHidden) (ne .Layout `archives`) (ne .Layout `search`) }}
+    {{- if and (not .Params.searchHidden) (ne .Layout `archives`) (ne .Layout `search`) (ne .Params.hiddenPage true) }}
     {{- $.Scratch.Add "index" (dict "title" .Title "content" .Plain "permalink" .Permalink "summary" .Summary) -}}
     {{- end }}
 {{- end -}}

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -42,6 +42,7 @@
 {{- $pages = where site.RegularPages "Type" "in" site.Params.mainSections }}
 {{- $pages = where $pages "Params.hiddenInHomeList" "!=" "true"  }}
 {{- end }}
+{{- $pages = where $pages "Params.hiddenPage" "!=" "true" }}
 
 {{- $paginator := .Paginate $pages }}
 

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -40,9 +40,9 @@
 
 {{- if .IsHome }}
 {{- $pages = where site.RegularPages "Type" "in" site.Params.mainSections }}
-{{- $pages = where $pages "Params.hiddenInHomeList" "!=" "true"  }}
+{{- $pages = where $pages "Params.hiddenInHomeList" "!=" true  }}
 {{- end }}
-{{- $pages = where $pages "Params.hiddenPage" "!=" "true" }}
+{{- $pages = where $pages "Params.hiddenPage" "!=" true }}
 
 {{- $paginator := .Paginate $pages }}
 

--- a/layouts/_default/rss.xml
+++ b/layouts/_default/rss.xml
@@ -33,7 +33,7 @@
     {{ printf "<atom:link href=%q rel=\"self\" type=%q />" .Permalink .MediaType | safeHTML }}
     {{- end -}}
     {{ range $pages }}
-    {{- if and (ne .Layout `search`) (ne .Layout `archives`) }}
+    {{- if and (ne .Layout `search`) (ne .Layout `archives`) (ne .Params.hiddenPage true) }}
     <item>
       <title>{{ .Title }}</title>
       <link>{{ .Permalink }}</link>

--- a/layouts/_default/sitemap.xml
+++ b/layouts/_default/sitemap.xml
@@ -1,0 +1,24 @@
+{{ printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+  xmlns:xhtml="http://www.w3.org/1999/xhtml">
+  {{ range .Data.Pages }}
+    {{- if .Permalink -}}
+  <url>
+    <loc>{{ .Permalink }}</loc>{{ if not .Lastmod.IsZero }}
+    <lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ end }}{{ with .Sitemap.ChangeFreq }}
+    <changefreq>{{ . }}</changefreq>{{ end }}{{ if ge .Sitemap.Priority 0.0 }}
+    <priority>{{ .Sitemap.Priority }}</priority>{{ end }}{{ if .IsTranslated }}{{ range .Translations }}
+    <xhtml:link
+                rel="alternate"
+                hreflang="{{ .Language.Lang }}"
+                href="{{ .Permalink }}"
+                />{{ end }}
+    <xhtml:link
+                rel="alternate"
+                hreflang="{{ .Language.Lang }}"
+                href="{{ .Permalink }}"
+                />{{ end }}
+  </url>
+    {{- end -}}
+  {{ end }}
+</urlset>

--- a/layouts/_default/sitemap.xml
+++ b/layouts/_default/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
   xmlns:xhtml="http://www.w3.org/1999/xhtml">
   {{ range .Data.Pages }}
-    {{- if .Permalink -}}
+    {{- if .Permalink | and (ne .Params.hiddenPage true) -}}
   <url>
     <loc>{{ .Permalink }}</loc>{{ if not .Lastmod.IsZero }}
     <lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ end }}{{ with .Sitemap.ChangeFreq }}

--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -14,7 +14,7 @@
 <ul class="terms-tags">
     {{- $type := .Type }}
     {{- range $term := .Data.Terms.Alphabetical  }}
-    {{- $termPages := where $term.Pages "Params.hiddenPage" "!=" "true" }}
+    {{- $termPages := where $term.Pages "Params.hiddenPage" "!=" true }}
     {{- if (len $termPages | ne 0) }}
     {{- $name := $term.Name }}
     {{- $count := len $termPages }}

--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -13,13 +13,16 @@
 
 <ul class="terms-tags">
     {{- $type := .Type }}
-    {{- range $key, $value := .Data.Terms.Alphabetical }}
-    {{- $name := .Name }}
-    {{- $count := .Count }}
+    {{- range $term := .Data.Terms.Alphabetical  }}
+    {{- $termPages := where $term.Pages "Params.hiddenPage" "!=" "true" }}
+    {{- if (len $termPages | ne 0) }}
+    {{- $name := $term.Name }}
+    {{- $count := len $termPages }}
     {{- with site.GetPage (printf "/%s/%s" $type $name) }}
     <li>
-        <a href="{{ .Permalink }}">{{ .Name }} <sup><strong><sup>{{ $count }}</sup></strong></sup> </a>
+        <a href="{{ .Permalink }}">{{ $name }} <sup><strong><sup>{{ $count }}</sup></strong></sup> </a>
     </li>
+    {{- end }}
     {{- end }}
     {{- end }}
 </ul>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,7 +1,7 @@
 <meta charset="utf-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-{{- if hugo.IsProduction | or (eq site.Params.env "production") | and (ne .Params.robotsNoIndex true) }}
+{{- if hugo.IsProduction | or (eq site.Params.env "production") | and (ne .Params.robotsNoIndex true) (ne .Params.hiddenPage true) }}
 <meta name="robots" content="index, follow">
 {{- else }}
 <meta name="robots" content="noindex, nofollow">

--- a/layouts/robots.txt
+++ b/layouts/robots.txt
@@ -1,7 +1,9 @@
 User-agent: *
-{{- if hugo.IsProduction | or (eq site.Params.env "production") }}
-Disallow:
-{{- else }}
+{{- if not (hugo.IsProduction | or (eq site.Params.env "production")) }}
 Disallow: /
+{{- else }}
+{{- range where site.RegularPages "Params.hiddenPage" true }}
+Disallow: {{ .RelPermalink }}
+{{- end }}
 {{- end }}
 Sitemap: {{ "sitemap.xml" | absURL }}


### PR DESCRIPTION
**What does this PR change? What problem does it solve?**
Completes and closes #712.

Changes from previous PR:
- fixed the terms layout
- tweaked the link render hook to only include the relevant `rel`(s) on a hiddenPage
- changed robots.txt layout to add a `Disallow` directive for every hiddenPage and its resources

**Was the change discussed in an issue or in the Discussions before?**
#712

## PR Checklist

- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have verified that the code works as described/as intended.
- [ ] This change adds a Social Icon which has a permissive license to use it.
- [x] This change **does not** include any CDN resources/links.
- [x] This change **does not** include any unrelated scripts such as bash and python scripts.
- [x] This change updates the overridden internal templates from HUGO's repository.
