### PR TITLE
Escape ampersand in HTML

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -7,7 +7,7 @@
     {{- end }}
     <span>
         Powered by
-        <a href="https://gohugo.io/" rel="noopener noreferrer" target="_blank">Hugo</a> &
+        <a href="https://gohugo.io/" rel="noopener noreferrer" target="_blank">Hugo</a> &amp;
         <a href="https://github.com/adityatelange/hugo-PaperMod/" rel="noopener" target="_blank">PaperMod</a>
     </span>
 </footer>


### PR DESCRIPTION
**What does this PR change? What problem does it solve?**

This PR fixes an unescaped ampersand in the HTML templates. The page renders fine without this but ampersands should be escaped in HTML.

**Was the change discussed in an issue or in the Discussions before?**

No

## PR Checklist

- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have verified that the code works as described/as intended.
- [ ] This change adds a Social Icon which has a permissive license to use it.
- [x] This change **does not** include any CDN resources/links.
- [x] This change **does not** include any unrelated scripts such as bash and python scripts.
- [ ] This change updates the overridden internal templates from HUGO's repository.
