### PR TITLE
added custom quora icon

### DIFF
--- a/layouts/partials/svg.html
+++ b/layouts/partials/svg.html
@@ -479,6 +479,10 @@
     <path
         d="M19.125 0H4.875A4.865 4.865 0 0 0 0 4.875v14.25C0 21.825 2.175 24 4.875 24h6.6c2.7 0 4.875-2.175 4.875-4.875V16.65h2.775c2.7 0 4.875-2.175 4.875-4.875v-6.9C24 2.175 21.825 0 19.125 0zM16.5 1.275h2.625a3.6 3.6 0 0 1 3.6 3.6v2.7H16.5v-6.3zM15.075 9v6.45H8.85V9h6.225zM8.85 1.2h6.225v6.375H8.85V1.2zM1.275 4.8a3.6 3.6 0 0 1 3.6-3.6H7.5v6.375H1.275V4.8zM7.5 9v6.45H1.2V9h6.3zm0 13.725H4.8a3.6 3.6 0 0 1-3.6-3.6V16.8h6.3v5.925zm7.575-3.525a3.6 3.6 0 0 1-3.6 3.6H8.85v-5.925h6.225V19.2zm7.65-7.35a3.6 3.6 0 0 1-3.6 3.6H16.5V9h6.225v2.85z" />
 </svg>
+{{- else if (eq $icon_name "quora") -}}
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor" stroke-linejoin="round" stroke-width="2" viewBox="0 0 24 24">
+    <path d="M11.8 16a5 5 0 1 1 3.7-1.6m-1 5.2a7 7 0 0 1-2.7.4 9 9 0 1 1 9-9c0 2.5-1 5-2.9 6.7m-4.5-5.6c2.4 1.4 3.2 4.6 5 6.7l2.8 3s-3.2.4-4.5-.3c-2.6-1.3-3.5-4.6-5.3-7l-2.3-2.7s3-.4 4.3.3z"/>
+</svg>
 {{- else if (eq $icon_name "qq") -}}
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
     stroke-linecap="round" stroke-linejoin="round">


### PR DESCRIPTION
<!--

## READ BEFORE OPENING A PR

Thank you for contributing to hugo-PaperMod!
Please fill out the following questions to make it easier for us to review your
changes. You do not need to check all the boxes below.

**NOTE**: PaperMod does not have any external dependencies fetched from 3rd party
CDN servers. However we do have custom Head/Footer extender templates which you can use
to add those to your website.
https://github.com/adityatelange/hugo-PaperMod/wiki/FAQs#custom-head--footer

-->


**What does this PR change? What problem does it solve?**

<!--
Adds missing icon for [Quora](quora.com).

![dark mode](https://user-images.githubusercontent.com/115934474/226178354-2ea85f75-e26d-4f6a-b9f6-197fb82b1803.png)

![light mode](https://user-images.githubusercontent.com/115934474/226178394-ddacbdd1-1662-498d-9134-0ffc76813a88.png)
-->


**Was the change discussed in an issue or in the Discussions before?**

<!--
No
-->


## PR Checklist

- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have verified that the code works as described/as intended.
- [x] This change adds a Social Icon which has a permissive license to use it.
- [x] This change **does not** include any CDN resources/links.
- [x] This change **does not** include any unrelated scripts such as bash and python scripts.
- [ ] This change updates the overridden internal templates from HUGO's repository.
