### PR TITLE
change <del> element CSS styling to use line-through

### DIFF
--- a/assets/css/common/post-single.css
+++ b/assets/css/common/post-single.css
@@ -83,8 +83,7 @@
 }
 
 .post-content del {
-    text-decoration: none;
-    background: linear-gradient(to right, var(--primary) 100%, transparent 0) 0 50%/1px 1px repeat-x;
+    text-decoration: line-through;
 }
 
 .post-content dl,


### PR DESCRIPTION
**What does this PR change? What problem does it solve?**

I used the markdown `~~strikethrough~~` markup in a blog post, and noticed that it was rendering weirdly in Firefox 111:

![Image showing a very thin and broken line through text](https://user-images.githubusercontent.com/3979034/228346340-1dcaeafc-9a8f-4d50-a575-1ce53a294a1c.png)

In Chrome it rendered correctly:

![Image showing normal strike-through text](https://user-images.githubusercontent.com/3979034/228346488-48a28388-0546-4672-b8ff-afbdccc7e7c3.png)


It turns out, that hugo converts `~~` to the [HTML `del` element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/del). This element was apparently not supported in Chrome until recently, which is why I guess this fix was introduced in hugo-Paper back in the day. hugo-Paper removed the original linear-gradient solution [in v6 released in July 2023](https://github.com/nanxiaobei/hugo-paper/commit/39f6f4e9b2f6d6beed74cc46325bc0157a40a2b1).

According to caniuse.com [only around 69% of mobile user and 22% desktop users use a browser that supports this element](https://caniuse.com/mdn-html_elements_del).
I assume that this will change rapidly with the Chrome support (Version 111, released March 7th 2023).
But I would still propose that we style this element manually, as it can be quite important to indicate that a phrase is no longer up to date/valid.

Therefore this change uses `text-decoration: line-through`  to archive the same effect across browsers.

After fix in Firefox 111:
![Correctly strike through text](https://user-images.githubusercontent.com/3979034/228348533-48bfa655-5405-447f-bace-bcf07c4be54c.png)

After fix in Chrome 111:
![Correctly strike through text](https://user-images.githubusercontent.com/3979034/228348668-f7e43833-6fe6-44ed-bd4e-bee2566cde3a.png)


**Was the change discussed in an issue or in the Discussions before?**

I couldn't find anything.

## PR Checklist

- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have verified that the code works as described/as intended.
- [ ] This change adds a Social Icon which has a permissive license to use it.
- [x] This change **does not** include any CDN resources/links.
- [x] This change **does not** include any unrelated scripts such as bash and python scripts.
- [ ] This change updates the overridden internal templates from HUGO's repository.
