### PR TITLE
Allow loading cover from /assets folder

### DIFF
--- a/layouts/partials/cover.html
+++ b/layouts/partials/cover.html
@@ -4,7 +4,9 @@
 <figure class="entry-cover">
     {{- $responsiveImages := (.Params.cover.responsiveImages | default site.Params.cover.responsiveImages) | default true }}
     {{- $addLink := (and site.Params.cover.linkFullImages (not $.IsHome)) }}
-    {{- $cover := (.Resources.ByType "image").GetMatch (printf "*%s*" (.Params.cover.image)) }}
+    {{- $pageBundleCover     := (.Resources.ByType "image").GetMatch (printf "*%s*" (.Params.cover.image)) }}
+    {{- $globalResourcesCover := (resources.ByType "image").GetMatch (printf "*%s*" (.Params.cover.image)) }}
+    {{- $cover := (or $pageBundleCover $globalResourcesCover)}}
     {{- if $cover -}}{{/* i.e it is present in page bundle */}}
         {{- if $addLink }}<a href="{{ (path.Join .RelPermalink .Params.cover.image) | absURL }}" target="_blank"
             rel="noopener noreferrer">{{ end -}}


### PR DESCRIPTION
**What does this PR change? What problem does it solve?**

My initial issue is that I store all cover images in the `/assets` folder, separate from my posts (to be precise, I even store them via git submodules in a different git repo). I still want to benefit from the Hugo Pipes image processing to render different image sizes.

Behaviour after the change:
By default, the cover is loaded from the page resources folder (same folder). If the image is not found, the (global) `/assets` folder is searched as well. If found, the same processing is done. Otherwise, the fallback remains with linking to the image directly.

Tested with hugo v0.111.3+extended
Hugo Pipes Docs (incl. `/assets` folder): https://gohugo.io/hugo-pipes/introduction/#asset-directory

## PR Checklist

- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have verified that the code works as described/as intended.
- [ ] This change adds a Social Icon which has a permissive license to use it.
- [x] This change **does not** include any CDN resources/links.
- [x] This change **does not** include any unrelated scripts such as bash and python scripts.
- [ ] This change updates the overridden internal templates from HUGO's repository.
