### PR TITLE
Fix RSS link for paginated list pages

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -10,7 +10,8 @@
   <h1>
     {{ .Title }}
     {{- if and (or (eq .Kind `term`) (eq .Kind `section`)) (.Param "ShowRssButtonInSectionTermList") }}
-    <a href="index.xml" title="RSS" aria-label="RSS">
+    {{- with .OutputFormats.Get "rss" }}
+    <a href="{{ .RelPermalink }}" title="RSS" aria-label="RSS">
       <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
         stroke-linecap="round" stroke-linejoin="round" height="23">
         <path d="M4 11a9 9 0 0 1 9 9" />
@@ -18,6 +19,7 @@
         <circle cx="5" cy="19" r="1" />
       </svg>
     </a>
+    {{- end }}
     {{- end }}
   </h1>
   {{- if .Description }}


### PR DESCRIPTION
**What does this PR change? What problem does it solve?**

The RSS link in list pages was previously hard-coded to `index.xml`, which doesn't work on paginated list pages because it might go to something like `/section/pages/2/index.xml` instead of `/section/index.xml`. I made it use `(.OutputFormats.Get "rss").RelPermalink` instead following the [example in Hugo's docs](https://gohugo.io/templates/rss/#reference-your-rss-feed-in-head).

## PR Checklist

- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have verified that the code works as described/as intended.
- [ ] This change adds a Social Icon which has a permissive license to use it.
- [x] This change **does not** include any CDN resources/links.
- [x] This change **does not** include any unrelated scripts such as bash and python scripts.
- [ ] This change updates the overridden internal templates from HUGO's repository.
