### PR TITLE
Add social icon for substack (#1129)

### DIFF
--- a/layouts/partials/svg.html
+++ b/layouts/partials/svg.html
@@ -584,6 +584,12 @@
     <path
         d="M15.387 17.944l-2.089-4.116h-3.065L15.387 24l5.15-10.172h-3.066m-7.008-5.599l2.836 5.598h4.172L10.463 0l-7 13.828h4.169"/>
 </svg>
+</svg>
+{{- else if (eq $icon_name "substack") -}}
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" stroke-width="2">
+    <path d="M22.539 8.242H1.46V5.406h21.08v2.836zM1.46 10.812V24L12 18.11 22.54 24V10.812H1.46zM22.54 0H1.46v2.836h21.08V0z"/>
+</svg>
+
 {{- else if (eq $icon_name "telegram") -}}
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
     stroke-linecap="round" stroke-linejoin="round">


### PR DESCRIPTION
<!--

## READ BEFORE OPENING A PR

Thank you for contributing to hugo-PaperMod!
Please fill out the following questions to make it easier for us to review your
changes. You do not need to check all the boxes below.

**NOTE**: PaperMod does not have any external dependencies fetched from 3rd party
CDN servers. However we do have custom Head/Footer extender templates which you can use
to add those to your website.
https://github.com/adityatelange/hugo-PaperMod/wiki/FAQs#custom-head--footer

-->


**What does this PR change? What problem does it solve?**

This adds Substack social icon. Here is some testing. Let me know what y'all think.

![Screenshot 2023-04-22 at 3 21 04 PM](https://user-images.githubusercontent.com/51132467/233759415-e6d72345-ccf2-45c6-ad2c-5b84b5445b4c.png)
![Screenshot 2023-04-22 at 3 21 32 PM](https://user-images.githubusercontent.com/51132467/233759417-afbd719c-159b-4191-a64d-ad9909a73953.png)

**Was the change discussed in an issue or in the Discussions before?**

Issue #1129. No discussion as far as I'm aware.


## PR Checklist

- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [ ] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have verified that the code works as described/as intended.
- [X] This change adds a Social Icon which has a permissive license to use it.
- [ ] This change **does not** include any CDN resources/links.
- [ ] This change **does not** include any unrelated scripts such as bash and python scripts.
- [ ] This change updates the overridden internal templates from HUGO's repository.




