### PR TITLE
Fixes adityatelange/hugo-PaperMod#898

### DIFF
--- a/content/posts/papermod/papermod-faq.md
+++ b/content/posts/papermod/papermod-faq.md
@@ -207,12 +207,12 @@ and can be added accordingly.
 
     ```
     params:
-    assets:
-        favicon: "<link / absolute url>"
-        favicon16x16:  "<link / absolute url>"
-        favicon32x32:  "<link / absolute url>"
-        apple_touch_icon:  "<link / absolute url>"
-        safari_pinned_tab:  "<link / absolute url>"
+        assets:
+            favicon: "<link / absolute url>"
+            favicon16x16:  "<link / absolute url>"
+            favicon32x32:  "<link / absolute url>"
+            apple_touch_icon:  "<link / absolute url>"
+            safari_pinned_tab:  "<link / absolute url>"
     ```
 
     - `absolute url` means direct links to external resource: ex. https://web.site/someimage.png
@@ -221,12 +221,12 @@ and can be added accordingly.
 
     ```
     params:
-    assets:
-        favicon: "/favicon.ico"
-        favicon16x16:  "/favicon-16x16.png"
-        favicon32x32:  "/favicon-32x32.png"
-        apple_touch_icon:  "/apple-touch-icon.png"
-        safari_pinned_tab:  "/safari-pinned-tab.svg"
+        assets:
+            favicon: "/favicon.ico"
+            favicon16x16:  "/favicon-16x16.png"
+            favicon32x32:  "/favicon-32x32.png"
+            apple_touch_icon:  "/apple-touch-icon.png"
+            safari_pinned_tab:  "/safari-pinned-tab.svg"
     ```
 
 ---


### PR DESCRIPTION
<!--

## READ BEFORE OPENING A PR

Thank you for contributing to hugo-PaperMod!
Please fill out the following questions to make it easier for us to review your
changes. You do not need to check all the boxes below.

**NOTE**: PaperMod does not have any external dependencies fetched from 3rd party
CDN servers. However we do have custom Head/Footer extender templates which you can use
to add those to your website.
https://github.com/adityatelange/hugo-PaperMod/wiki/FAQs#custom-head--footer

-->


**What does this PR change? What problem does it solve?**

<!--
Describe the changes and their purpose here, as detailed as and if  needed.

Please do not add 2 unrelated changes in a single PR as it is difficult to track/revert those in future.
-->

This pull request addresses [issue #898](https://github.com/adityatelange/hugo-PaperMod/issues/898), which resolves the incorrect indentation issue for the custom favicon demo on the [FAQs page](https://adityatelange.github.io/hugo-PaperMod/posts/papermod/papermod-faq/#adding-custom-favicons).

**Was the change discussed in an issue or in the Discussions before?**

The issue regarding the incorrect indentation was discussed in detail in [issue #898](https://github.com/adityatelange/hugo-PaperMod/issues/898), which was closed without a proper resolution.

<!--
Link issues and relevant Discussions posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

## PR Checklist

- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have verified that the code works as described/as intended.
- [ ] This change adds a Social Icon which has a permissive license to use it.
- [x] This change **does not** include any CDN resources/links.
- [x] This change **does not** include any unrelated scripts such as bash and python scripts.
- [ ] This change updates the overridden internal templates from HUGO's repository.
