### PR TITLE
Fix #1224 Deprecated code warning in hugo v0.112.0

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -36,7 +36,7 @@
   {{- end }}
 
   <footer class="post-footer">
-    {{- $tags := .Language.Params.Taxonomies.tag | default "tags" }}
+    {{- $tags := .Site.Params.Taxonomies.tag | default "tags" }}
     <ul class="post-tags">
       {{- range ($.GetTerms $tags) }}
       <li><a href="{{ .Permalink }}">{{ .LinkTitle }}</a></li>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -104,7 +104,7 @@
                     {{- range . -}}
                     {{- if ne $lang .Lang }}
                     <li>
-                        <a href="{{- .Permalink -}}" title="{{ .Language.Params.languageAltTitle | default (.Language.LanguageName | emojify) | default (.Lang | title) }}"
+                        <a href="{{- .Permalink -}}" title="{{ .Site.Params.languageAltTitle | default (.Language.LanguageName | emojify) | default (.Lang | title) }}"
                             aria-label="{{ .Language.LanguageName | default (.Lang | title) }}">
                             {{- if (and site.Params.displayFullLangName (.Language.LanguageName)) }}
                             {{- .Language.LanguageName | emojify -}}


### PR DESCRIPTION
Changed site variables from 'Language.Params' -> 'Site.Params'.
Note this change may conflict with hugo versions less than v0.112.0

See hugo docs:
  https://gohugo.io/content-management/multilingual/#changes-in-hugo-01120

See hugo-PaperMod Issue:
  https://github.com/adityatelange/hugo-PaperMod/issues/1224

	modified:   _default/single.html
	modified:   partials/header.html

**What does this PR change? What problem does it solve?**
Issue described here: https://github.com/adityatelange/hugo-PaperMod/issues/1224


**Was the change discussed in an issue or in the Discussions before?**
No.

## PR Checklist

- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have verified that the code works as described/as intended.
- [ ] This change adds a Social Icon which has a permissive license to use it.
- [x] This change **does not** include any CDN resources/links.
- [x] This change **does not** include any unrelated scripts such as bash and python scripts.
- [?] This change updates the overridden internal templates from HUGO's repository.

I'm not 100% certain about the last item in the PR checklist. Please let me know if this is an issue.