### PR TITLE
feat: allow hiding author in post_meta

### DIFF
--- a/layouts/partials/post_meta.html
+++ b/layouts/partials/post_meta.html
@@ -12,8 +12,10 @@
 {{- $scratch.Add "meta" (slice (i18n "words" .WordCount | default (printf "%d words" .WordCount))) }}
 {{- end }}
 
+{{- if (.Param "ShowAuthor") -}}
 {{- with (partial "author.html" .) }}
 {{- $scratch.Add "meta" (slice .) }}
+{{- end }}
 {{- end }}
 
 {{- with ($scratch.Get "meta") }}

--- a/layouts/partials/post_meta.html
+++ b/layouts/partials/post_meta.html
@@ -12,7 +12,7 @@
 {{- $scratch.Add "meta" (slice (i18n "words" .WordCount | default (printf "%d words" .WordCount))) }}
 {{- end }}
 
-{{- if (.Param "ShowAuthor") -}}
+{{- if not (.Param "hideAuthor") -}}
 {{- with (partial "author.html" .) }}
 {{- $scratch.Add "meta" (slice .) }}
 {{- end }}


### PR DESCRIPTION
**What does this PR change? What problem does it solve?**

For a person's site, in most cases the author is the person, and displaying it on every post and list may be redundant.

Setting the `params.author` in the configuration to empty will achieve the hidden effect, but it will also empty the value of `<meta name="author">`.

So add `ShowAuthor`.

**Was the change discussed in an issue or in the Discussions before?**

none

## PR Checklist

- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have verified that the code works as described/as intended.
- [ ] This change adds a Social Icon which has a permissive license to use it.
- [x] This change **does not** include any CDN resources/links.
- [x] This change **does not** include any unrelated scripts such as bash and python scripts.
- [ ] This change updates the overridden internal templates from HUGO's repository.
