### PR TITLE
Make exampleSite work with latest hugo version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ _testmain.go
 
 /public
 .DS_Store
+.hugo_build.lock

--- a/config.yml
+++ b/config.yml
@@ -42,26 +42,12 @@ languages:
 
     fr:
         languageName: ":fr:"
-        languageAltTitle: French
         weight: 2
         title: PaperModL2
         taxonomies:
           category: FRcategories
           tag: FRtags
           series: FRseries
-        profileMode:
-            enabled: true
-            title: PaperMod
-            imageUrl: "https://raw.githubusercontent.com/twitter/twemoji/master/assets/svg/1f317.svg"
-            imageTitle: ProfileMode image
-            # imageWidth: 120
-            # imageHeight: 120
-            subtitle: "☄️ Fast | ☁️ Fluent | 🌙 Smooth | 📱 Responsive"
-            buttons:
-                - name: Blog
-                  url: posts
-                - name: Profile Mode
-                  url: https://github.com/adityatelange/hugo-PaperMod/wiki/Features#profile-mode
         menu:
             main:
                 - name: Archive
@@ -78,14 +64,26 @@ languages:
                   weight: 10
                 - name: NullLink
                   url: "#"
+        params:
+            languageAltTitle: French
+            profileMode:
+                enabled: true
+                title: PaperMod
+                imageUrl: https://raw.githubusercontent.com/twitter/twemoji/master/assets/svg/1f317.svg
+                imageTitle: ProfileMode image
+                # imageWidth: 120
+                # imageHeight: 120
+                subtitle: "☄️ Fast | ☁️ Fluent | 🌙 Smooth | 📱 Responsive"
+                buttons:
+                    - name: Blog
+                      url: posts
+                    - name: Profile Mode
+                      url: https://github.com/adityatelange/hugo-PaperMod/wiki/Features#profile-mode
 
     fa:
         languagedirection: rtl
         weight: 3
         title: PaperMod RTL
-        homeInfoParams:
-            Title: "Hi there \U0001F44B"
-            Content: Welcome to RTL layout
         taxonomies:
           category: FAcategories
           tag: FAtags
@@ -95,6 +93,10 @@ languages:
                 - name: FATags
                   url: fatags
                   weight: 10
+        params:
+            homeInfoParams:
+                Title: "Hi there \U0001F44B"
+                Content: Welcome to RTL layout
 
 outputs:
     home:


### PR DESCRIPTION
**What does this PR change? What problem does it solve?**

It makes the exampleSite work with latest version hugo  version `v0.115.3`.

What this PR does:

* update theme submodule in exampleSIte to latest version v0.7.0
* fix/avoid deprecation warnings about language parameters when running exampleSite with latest hugo version.

**Was the change discussed in an issue or in the Discussions before?**

Yes, two different users reported this issue in #1249.

## PR Checklist

- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have verified that the code works as described/as intended.
- [x] This change **does not** include any CDN resources/links.
- [x] This change **does not** include any unrelated scripts such as bash and python scripts.

This PR closes #1249.