### PR TITLE
socialIcons, fix: apply safeURL to make all URI schemes work

### DIFF
--- a/layouts/partials/social_icons.html
+++ b/layouts/partials/social_icons.html
@@ -1,6 +1,6 @@
 <div class="social-icons">
     {{- range . }}
-    <a href="{{ trim .url " " }}" target="_blank" rel="noopener noreferrer me" title="{{ (.title | default .name) | title }}">
+    <a href="{{ trim .url " " | safeURL }}" target="_blank" rel="noopener noreferrer me" title="{{ (.title | default .name) | title }}">
         {{ partial "svg.html" . }}
     </a>
     {{- end }}

--- a/layouts/partials/templates/schema_json.html
+++ b/layouts/partials/templates/schema_json.html
@@ -11,7 +11,7 @@
     {{- if site.Params.schema.sameAs }}
       {{ range $i, $e := site.Params.schema.sameAs }}{{ if $i }}, {{ end }}{{ trim $e " " }}{{ end }}
     {{- else}}
-      {{ range $i, $e := site.Params.SocialIcons }}{{ if $i }}, {{ end }}{{ trim $e.url " " }}{{ end }}
+      {{ range $i, $e := site.Params.SocialIcons }}{{ if $i }}, {{ end }}{{ trim $e.url " " | safeURL }}{{ end }}
     {{- end}}
   ]
 }


### PR DESCRIPTION
**What does this PR change? What problem does it solve?**

Currently, a socialIcon defined as below does **not** work:

```
socialIcons:
  - name: xmpp
    url: xmpp:address@instance.com
```

This PR fixes this.

**Was the change discussed in an issue or in the Discussions before?**

Yes, this issue was discussed in this [thread](https://discourse.gohugo.io/t/url-scheme-doesnt-work/45290) on hugo discourse board.

## PR Checklist

- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have verified that the code works as described/as intended.
- [x] This change **does not** include any CDN resources/links.
- [x] This change **does not** include any unrelated scripts such as bash and python scripts.
