### PR TITLE
fix: Adjust margin-bottom in nested lists

### DIFF
--- a/assets/css/common/post-single.css
+++ b/assets/css/common/post-single.css
@@ -103,7 +103,9 @@
     margin-top: 5px;
 }
 
-.post-content li p {
+.post-content li ol,
+.post-content li p,
+.post-content li ul {
     margin-bottom: 0;
 }
 


### PR DESCRIPTION
**What does this PR change? What problem does it solve?**

Remove extra margin-bottom to nested lists.
Screenshots are here: https://github.com/adityatelange/hugo-PaperMod/issues/1251

**Was the change discussed in an issue or in the Discussions before?**

closes https://github.com/adityatelange/hugo-PaperMod/issues/1251

## PR Checklist

- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have verified that the code works as described/as intended.
- [ ] This change adds a Social Icon which has a permissive license to use it.
- [x] This change **does not** include any CDN resources/links.
- [x] This change **does not** include any unrelated scripts such as bash and python scripts.
- [ ] This change updates the overridden internal templates from HUGO's repository.
