### PR TITLE
fix: Font size in the code block may be larger on iOS Safari

### DIFF
--- a/assets/css/core/reset.css
+++ b/assets/css/core/reset.css
@@ -7,6 +7,8 @@
 html {
     -webkit-tap-highlight-color: transparent;
     overflow-y: scroll;
+    -webkit-text-size-adjust: 100%;
+    text-size-adjust: 100%;
 }
 
 a,


### PR DESCRIPTION
**What does this PR change? What problem does it solve?**

Font size in the code block may be larger on iOS Safari.
This can be solved by specifying `-webkit-text-size-adjust: 100%`.

Some Reset CSS specify this property.
https://github.com/necolas/normalize.css/blob/fc091cce1534909334c1911709a39c22d406977b/normalize.css#L13 https://github.com/csstools/sanitize.css/blob/092d0d85922bfa72d28e9e8d25d80a5437c8df44/sanitize.css#L43

| Before | After |
| - | - |
| <img width="250" src="https://github.com/shimoju/shimoju.jp/assets/1928324/9083eb86-58cd-4ad3-a916-2f8b0ea69f85"> | <img width="250" src="https://github.com/shimoju/shimoju.jp/assets/1928324/7fdc9e47-4cbf-49a1-862b-9fb772174ca1"> |

**Was the change discussed in an issue or in the Discussions before?**

No.

## PR Checklist

- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have verified that the code works as described/as intended.
- [ ] This change adds a Social Icon which has a permissive license to use it.
- [x] This change **does not** include any CDN resources/links.
- [x] This change **does not** include any unrelated scripts such as bash and python scripts.
- [ ] This change updates the overridden internal templates from HUGO's repository.
