### PR TITLE
Edit farsi translation and add 'words'

### DIFF
--- a/i18n/fa.yaml
+++ b/i18n/fa.yaml
@@ -1,19 +1,24 @@
 - id: prev_page
-  translation: "صفحه قبلی"
+  translation: "صفحه قبل"
 
 - id: next_page
-  translation: "صفحه بعدی"
+  translation: "صفحه بعد"
 
 - id: read_time
   translation:
-    one: "۱ دقیقه"
+    one : "1 دقیقه"
     other: "{{ .Count }} دقیقه"
+
+- id: words
+  translation:
+    one : "کلمه"
+    other: "{{ .Count }} کلمه"
 
 - id: toc
   translation: "فهرست مطالب"
 
 - id: translations
-  translation: "ترجمه ها"
+  translation: "ترجمه‌ها"
 
 - id: home
   translation: "خانه"


### PR DESCRIPTION
I suggest more comfortable translation for 'prev_page' and 'next_page'. Also, I added farsi translation for missing 'words'.

**What does this PR change? What problem does it solve?**

There are more comfortable farsi translations for 'prev_page' and 'next_page'. also the translation of 'words' was missing in farsi. because of different directions, It ruins the style of the text!

**Was the change discussed in an issue or in the Discussions before?**

No, I just noticed and decided to solve it.


## PR Checklist

- [x] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [ ] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have verified that the code works as described/as intended.
- [ ] This change adds a Social Icon which has a permissive license to use it.
- [ ] This change **does not** include any CDN resources/links.
- [ ] This change **does not** include any unrelated scripts such as bash and python scripts.
- [ ] This change updates the overridden internal templates from HUGO's repository.