### PR TITLE
Add the social icon for Pleroma

### DIFF
--- a/layouts/partials/svg.html
+++ b/layouts/partials/svg.html
@@ -497,6 +497,10 @@
 <svg width="24" height="24" version="1.1" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
  <path id="pixelfed" d="m12 .99649c-6.077 0-11.004 4.9264-11.004 11.004 0 6.077 4.9264 11.004 11.004 11.004 6.077 0 11.004-4.9264 11.004-11.004 0-6.077-4.9264-11.004-11.004-11.004zm-1.7683 6.7017h2.9133c1.9016 1e-6 3.4428 1.5006 3.4428 3.3518 0 1.8512-1.5414 3.3526-3.4428 3.3526h-2.0185l-2.8816 2.756v-7.5262c0-1.068.8896-1.9342 1.9867-1.9342z" fill="none" stroke="currentColor" stroke-width="1.993"/>
 </svg>
+{{- else if (eq $icon_name "pleroma") -}}
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+    <path d="M6.36 0A1.868 1.868 0 004.49 1.868V24h5.964V0zm7.113 0v12h4.168a1.868 1.868 0 001.868-1.868V0zm0 18.036V24h4.168a1.868 1.868 0 001.868-1.868v-4.096Z"/>
+</svg>
 {{- else if (eq $icon_name "qq") -}}
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
     stroke-linecap="round" stroke-linejoin="round">


### PR DESCRIPTION
<!--

## READ BEFORE OPENING A PR

Thank you for contributing to hugo-PaperMod!
Please fill out the following questions to make it easier for us to review your
changes. You do not need to check all the boxes below.

**NOTE**: PaperMod does not have any external dependencies fetched from 3rd party
CDN servers. However we do have custom Head/Footer extender templates which you can use
to add those to your website.
https://github.com/adityatelange/hugo-PaperMod/wiki/FAQs#custom-head--footer

-->


**What does this PR change? What problem does it solve?**

Add the social icon for Pleroma, a software of Fediverse social network.

- This icon is from [Simple Icons](https://simpleicons.org/?q=pleroma) with some adjustment to fit this project.
- Pleroma official [website](https://pleroma.social/).

![1](https://github.com/adityatelange/hugo-PaperMod/assets/63153334/4960505a-88e8-4323-b5b0-c532e5b619df) ![2](https://github.com/adityatelange/hugo-PaperMod/assets/63153334/fba20520-8329-4836-8a4a-2b42717ab192)

**Was the change discussed in an issue or in the Discussions before?**

No.


## PR Checklist

- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have verified that the code works as described/as intended.
- [x] This change adds a Social Icon which has a permissive license to use it.
- [x] This change **does not** include any CDN resources/links.
- [x] This change **does not** include any unrelated scripts such as bash and python scripts.
- [ ] This change updates the overridden internal templates from HUGO's repository.
