### PR TITLE
introduce editPost.appendQueryParam

### DIFF
--- a/layouts/partials/edit_post.html
+++ b/layouts/partials/edit_post.html
@@ -2,7 +2,7 @@
 {{- $fileUrlPath := path.Join .File.Path }}
 
 {{- if or .Params.author site.Params.author (.Param "ShowReadingTime") (not .Date.IsZero) .IsTranslated }}&nbsp;|&nbsp;{{- end -}}
-<a href="{{ .Params.editPost.URL | default site.Params.editPost.URL }}{{ if .Params.editPost.appendFilePath | default ( site.Params.editPost.appendFilePath | default false ) }}/{{ $fileUrlPath }}{{ end }}" rel="noopener noreferrer" target="_blank">
+<a href="{{ .Params.editPost.URL | default site.Params.editPost.URL }}{{ if .Params.editPost.appendFilePath | default ( site.Params.editPost.appendFilePath | default false ) }}/{{ $fileUrlPath }}{{ end }}{{ if .Params.editPost.appendQueryParam | default false}}?{{.Params.editPost.appendQueryParam | safeURL}}{{end}}" rel="noopener noreferrer" target="_blank">
     {{- .Params.editPost.Text | default (site.Params.editPost.Text | default (i18n "edit_post" | default "Edit")) -}}
 </a>
 {{- end }}


### PR DESCRIPTION
**What does this PR change? What problem does it solve?**

The `editPost` feature is great to invite visitors to contribute. Linking to Github code, the default "rendered" view of a markdown is sometimes not so useful. This PR introduces a parameter `editPost.appendQueryParam` to allow to add query parameters to the final URL. This allows to create a link like `https://github.com/adityatelange/hugo-PaperMod/blob/exampleSite/content/posts/papermod/papermod-installation.md?plain=1` to show the plain representation of the markdown.

**Was the change discussed in an issue or in the Discussions before?**

No

## PR Checklist

- [x ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [x ] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x ] I have verified that the code works as described/as intended.
- [x ] This change adds a Social Icon which has a permissive license to use it.
- [x ] This change **does not** include any CDN resources/links.
- [x ] This change **does not** include any unrelated scripts such as bash and python scripts.
- [x ] This change updates the overridden internal templates from HUGO's repository.
