### PR TITLE
Use version appropriate Go module path

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/adityatelange/hugo-PaperMod
+module github.com/adityatelange/hugo-PaperMod/v7
 
 go 1.12


### PR DESCRIPTION
## What does this PR change? What problem does it solve?

This theme is packaged as a [Go module](https://go.dev/ref/mod) in order to allow it to be managed as a dependency of Hugo-based websites.

There are two problems that cause this theme to be difficult to use as a Go module dependency:

- Non-compliant module path
- Non-compliant tag names

This PR resolves the first of these problems by adding the required `/v7` suffix to the Go module path, bringing it into compliance with the Go module framework.

The problem of non-compliant tag names must be fixed by an adjustment to the release procedure rather than a PR. However, this PR lays the groundwork for the use of compliant tag names in future releases.

Using a compliant module path as well as compliant tag names would benefit the users of this theme by allowing them to manage the dependency in a safe and efficient manner.

### Module path

A Go module is identified by a "module path". The Go module framework requires that this path have a major version suffix if the project is at a version of 2.0.0 or above.

This project is at version 7.0, so its Go module path `github.com/adityatelange/hugo-PaperMod` violates this requirement.

### Tag names

Due to the current use of a tag name format that does not meet the [the semver-compliant requirement of the Go module framework](https://go.dev/ref/mod#versions), the standard procedure for installing the theme in a Hugo-based website as a Go module dependency results in a potentially unstable beta version of the theme from the tip of the theme repository's default branch being installed.

The resulting "[pseudo-version](https://go.dev/ref/mod#pseudo-versions)" of the dependency (e.g., `v0.0.0-20230826144857-efe4cb45161b`) makes it so that updates of the dependency cannot be managed automatically via the popular [**Dependabot**](https://docs.github.com/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates) service.

## Was the change discussed in an issue or in the Discussions before?

No

## Additional Context

Following the merge of this pull request, [the instructions for installation as a Go module dependency](https://github.com/adityatelange/hugo-PaperMod/wiki/Installation#additional-method-by-701) should be updated with the new module path:

```diff
 module:
   imports:
-    - path: github.com/adityatelange/hugo-PaperMod
+    - path: github.com/adityatelange/hugo-PaperMod/v7
```

However, this will not be a breaking change even for those using the previous module path as it will continue to function as before.

## PR Checklist

- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have verified that the code works as described/as intended.
- [ ] This change adds a Social Icon which has a permissive license to use it.
- [x] This change **does not** include any CDN resources/links.
- [x] This change **does not** include any unrelated scripts such as bash and python scripts.
- [ ] This change updates the overridden internal templates from HUGO's repository.
