### PR TITLE
 Add logic to use .Description instead of .Summary

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -72,7 +72,11 @@
       {{- if .Draft }}<sup><span class="entry-isdraft">&nbsp;&nbsp;[draft]</span></sup>{{- end }}
     </h2>
   </header>
-  {{- if (ne (.Param "hideSummary") true) }}
+  {{- if and (.Description) (.Param "useDescription") }}
+  <div class="entry-content">
+    <p>{{ .Description | plainify | htmlUnescape }}</p>
+  </div>
+  {{- else if (ne (.Param "hideSummary") true) }}
   <div class="entry-content">
     <p>{{ .Summary | plainify | htmlUnescape }}{{ if .Truncated }}...{{ end }}</p>
   </div>


### PR DESCRIPTION
Adds a check for a useDescription param which will check for a description field in a post and use it instead of the .Summary when producing list.html. If a description is unavailable and hideSummary is not true, the summary will show as normal.

<!--

## READ BEFORE OPENING A PR

Thank you for contributing to hugo-PaperMod!
Please fill out the following questions to make it easier for us to review your
changes. You do not need to check all the boxes below.

**NOTE**: PaperMod does not have any external dependencies fetched from 3rd party
CDN servers. However we do have custom Head/Footer extender templates which you can use
to add those to your website.
https://github.com/adityatelange/hugo-PaperMod/wiki/FAQs#custom-head--footer

-->


**What does this PR change? What problem does it solve?**

Changes the logic in using the .Summary when creating a list of posts.

Allows users to specify a useDescription param to check for and use a short description instead of the summary in the entry-content div.


**Was the change discussed in an issue or in the Discussions before?**

My own discussion https://github.com/adityatelange/hugo-PaperMod/discussions/1323

Somewhat related to https://github.com/adityatelange/hugo-PaperMod/discussions/148


## PR Checklist

- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have verified that the code works as described/as intended.
- [ ] This change adds a Social Icon which has a permissive license to use it.
- [x] This change **does not** include any CDN resources/links.
- [x] This change **does not** include any unrelated scripts such as bash and python scripts.
- [x] This change updates the overridden internal templates from HUGO's repository.
