### PR TITLE
Add ability to load more partials in header

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -40,6 +40,9 @@
 {{- end }}
 
 <header class="header">
+    {{ if templates.Exists "partials/extend_header_before.html" }}
+    {{- partial "extend_header_before.html" . -}}
+    {{ end }}
     <nav class="nav">
         <div class="logo">
             {{- $label_text := (site.Params.label.text | default site.Title) }}
@@ -121,6 +124,9 @@
         </div>
         {{- $currentPage := . }}
         <ul id="menu">
+            {{ if templates.Exists "partials/extend_header_menu_items_before.html" }}
+            {{- partial "extend_header_menu_items_before.html" . -}}
+            {{ end }}
             {{- range site.Menus.main }}
             {{- $menu_item_url := (cond (strings.HasSuffix .URL "/") .URL (printf "%s/" .URL) ) | absLangURL }}
             {{- $page_url:= $currentPage.Permalink | absLangURL }}
@@ -144,6 +150,12 @@
                 </a>
             </li>
             {{- end }}
+            {{ if templates.Exists "partials/extend_header_menu_items_after.html" }}
+            {{- partial "extend_header_menu_items_after.html" . -}}
+            {{ end }}
         </ul>
     </nav>
+    {{ if templates.Exists "partials/extend_header_after.html" }}
+    {{- partial "extend_header_after.html" . -}}
+    {{ end }}
 </header>


### PR DESCRIPTION
Hello,

**What problem does it solve?**

This PR adds ability to load custom partials in different parts of `header.html`, so there will be no need in changing upstream (PaperMod) `header.html` file.

## PR Checklist

 - [X] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [X] I have verified that the code works as described/as intended.
- [X] This change **does not** include any CDN resources/links.
- [X] This change **does not** include any unrelated scripts such as bash and python scripts.
- [X] This change updates the overridden internal templates from HUGO's repository.
