### PR TITLE
feat: add last modified date to post meta

### DIFF
--- a/i18n/de.yaml
+++ b/i18n/de.yaml
@@ -31,3 +31,6 @@
 
 - id: code_copied
   translation: "Kopiert!"
+
+- id: lastmod
+  translation: "Zuletzt geändert"

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -31,3 +31,6 @@
 
 - id: code_copied
   translation: "copied!"
+
+- id: lastmod
+  translation: "Last Modified"

--- a/layouts/partials/post_meta.html
+++ b/layouts/partials/post_meta.html
@@ -4,6 +4,10 @@
 {{- $scratch.Add "meta" (slice (printf "<span title='%s'>%s</span>" (.Date) (.Date | time.Format (default "January 2, 2006" site.Params.DateFormat)))) }}
 {{- end }}
 
+{{- if and (.Param "Lastmod") (ne (.Param "Lastmod"| time.Format "2023-10-15") (.Date | time.Format "2023-10-15" )) }}
+{{- $scratch.Add "meta" (slice (printf "<span title='%s'>%s: %s</span>" (.Lastmod) (i18n "lastmod") (.Lastmod | time.Format (default "January 2, 2006" site.Params.DateFormat)))) }}
+{{- end }}
+
 {{- if (.Param "ShowReadingTime") -}}
 {{- $scratch.Add "meta" (slice (i18n "read_time" .ReadingTime | default (printf "%d min" .ReadingTime))) }}
 {{- end }}


### PR DESCRIPTION
**What does this PR change? What problem does it solve?**

This PR adds the "last modified" date to the post meta section in case a last modified is present and is not equal to the original post date.


**Was the change discussed in an issue or in the Discussions before?**

Closes #1037


## PR Checklist

- [] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have verified that the code works as described/as intended.
- [ ] This change adds a Social Icon which has a permissive license to use it.
- [x] This change **does not** include any CDN resources/links.
- [x] This change **does not** include any unrelated scripts such as bash and python scripts.
- [ ] This change updates the overridden internal templates from HUGO's repository.
