### PR TITLE
add cover image to rss

### DIFF
--- a/layouts/_default/rss.xml
+++ b/layouts/_default/rss.xml
@@ -73,8 +73,17 @@
       {{- with $authorEmail }}<author>{{ . }}{{ with $authorName }} ({{ . }}){{ end }}</author>{{ end }}
       <guid>{{ .Permalink }}</guid>
       <description>{{ with .Description | html }}{{ . }}{{ else }}{{ .Summary | html }}{{ end -}}</description>
-      {{- if and site.Params.ShowFullTextinRSS .Content }}
-      <content:encoded>{{ (printf "<![CDATA[%s]]>" .Content) | safeHTML }}</content:encoded>
+      {{- $isCoverHidden := .Params.cover.hidden | default site.Params.cover.hiddenInSingle | default site.Params.cover.hidden }}
+      {{- $cover := (partial "cover.html" (dict "cxt" . "IsSingle" false "IsHome" false "isHidden" $isCoverHidden)) -}}
+      {{- if (or $cover (and site.Params.ShowFullTextinRSS .Content)) -}}
+          <content:encoded>
+          {{- if $cover -}}
+              {{ (printf "<![CDATA[%s]]>" $cover) | safeHTML }}
+          {{- end -}}
+          {{- if and site.Params.ShowFullTextinRSS .Content }}
+               {{ (printf "<![CDATA[%s]]>" .Content) | safeHTML }}
+          {{- end -}}
+          </content:encoded>
       {{- end }}
     </item>
     {{- end }}


### PR DESCRIPTION
<!--

## READ BEFORE OPENING A PR

Thank you for contributing to hugo-PaperMod!
Please fill out the following questions to make it easier for us to review your
changes. You do not need to check all the boxes below.

**NOTE**: PaperMod does not have any external dependencies fetched from 3rd party
CDN servers. However we do have custom Head/Footer extender templates which you can use
to add those to your website.
https://github.com/adityatelange/hugo-PaperMod/wiki/FAQs#custom-head--footer

-->


**What does this PR change? What problem does it solve?**

<!--
Describe the changes and their purpose here, as detailed as and if  needed.

Please do not add 2 unrelated changes in a single PR as it is difficult to track/revert those in future.
-->


**Was the change discussed in an issue or in the Discussions before?**
Related issue: #891

Include cover image into rss feed. Example in the screenshot:

![image](https://github.com/adityatelange/hugo-PaperMod/assets/1962652/ffc28c87-3572-40a4-bbd9-196cd87692bb)

This PR also restores the removed xmlns: ` xmlns:content="http://purl.org/rss/1.0/modules/content/"`
It was removed by https://github.com/adityatelange/hugo-PaperMod/commit/00488d01463fc8c8db9fbda3f6060a0b5b373464 , which broke the use of the `content:encoding` tag.

I chose to keep it as a single change, since the xmlns was an accidental regression, and this PR itself is small.


## PR Checklist

- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have verified that the code works as described/as intended.
- [ ] This change adds a Social Icon which has a permissive license to use it.
- [ ] (restored the CDN link which was used before) This change **does not** include any CDN resources/links.
- [x] This change **does not** include any unrelated scripts such as bash and python scripts.
- [ ] This change updates the overridden internal templates from HUGO's repository.
