### PR TITLE
tags in rss displayed

### DIFF
--- a/layouts/_default/rss.xml
+++ b/layouts/_default/rss.xml
@@ -42,6 +42,10 @@
 {{- if ge $limit 1 }}
 {{- $pages = $pages | first $limit }}
 {{- end }}
+{{- $defaultTaxonomies := slice }}
+{{- range $taxonomy, $v := site.Taxonomies}}
+  {{- $defaultTaxonomies = $defaultTaxonomies | append $taxonomy }}
+{{- end}}
 {{- printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:content="http://purl.org/rss/1.0/modules/content/">
   <channel>
@@ -64,17 +68,23 @@
     {{- with .OutputFormats.Get "RSS" }}
     {{ printf "<atom:link href=%q rel=\"self\" type=%q />" .Permalink .MediaType | safeHTML }}
     {{- end }}
-    {{- range $pages }}
-    {{- if and (ne .Layout `search`) (ne .Layout `archives`) }}
+    {{ range $page := $pages }}
+    {{- if and (ne $page.Layout `search`) (ne $page.Layout `archives`) }}
     <item>
-      <title>{{ .Title }}</title>
-      <link>{{ .Permalink }}</link>
-      <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
+      <title>{{ $page.Title }}</title>
+      <link>{{ $page.Permalink }}</link>
+      <pubDate>{{ $page.Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
       {{- with $authorEmail }}<author>{{ . }}{{ with $authorName }} ({{ . }}){{ end }}</author>{{ end }}
-      <guid>{{ .Permalink }}</guid>
-      <description>{{ with .Description | html }}{{ . }}{{ else }}{{ .Summary | html }}{{ end -}}</description>
-      {{- if and site.Params.ShowFullTextinRSS .Content }}
-      <content:encoded>{{ (printf "<![CDATA[%s]]>" .Content) | safeHTML }}</content:encoded>
+      <guid>{{ $page.Permalink }}</guid>
+      <description>{{ with $page.Description | html }}{{ . }}{{ else }}{{ $page.Summary | html }}{{ end -}}</description>
+      {{- $taxonomies := (site.Params.TaxonomiesInRSS | default $defaultTaxonomies ) }}
+      {{- range $taxonomy := $taxonomies }}
+        {{- range $tag := ($page.GetTerms $taxonomy) }}
+          <category domain="{{ $taxonomy }}">{{ $tag.LinkTitle }}</category>
+        {{- end }}
+      {{- end }}
+      {{- if and site.Params.ShowFullTextinRSS $page.Content }}
+        <content:encoded>{{ (printf "<![CDATA[%s]]>" $page.Content) | safeHTML }}</content:encoded>
       {{- end }}
     </item>
     {{- end }}


### PR DESCRIPTION
Display tags in RSS feed.  Follows rss item cateogory spec: https://www.rssboard.org/rss-profile#element-channel-item-category

By default All site taxonomies are used. One however can choose taxonomies to include into RSS manually:

hugo.toml
```
params:
  TaxonomiesInRSS: ["tags", "categories"]    
```

## PR Checklist

- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have verified that the code works as described/as intended.
- [ ] This change adds a Social Icon which has a permissive license to use it.
- [x] This change **does not** include any CDN resources/links.
- [x] This change **does not** include any unrelated scripts such as bash and python scripts.
- [ ] This change updates the overridden internal templates from HUGO's repository.
