### PR TITLE
support relative paths for opengraph images

### DIFF
--- a/layouts/partials/templates/opengraph.html
+++ b/layouts/partials/templates/opengraph.html
@@ -11,7 +11,7 @@
 {{- else }}
 
 {{- with $.Params.images -}}
-{{- range first 6 . }}<meta property="og:image" content="{{ . | absURL }}" />{{ end -}}
+{{- range first 6 . }}<meta property="og:image" content="{{ index (findRE "^/.*" . 1) 0 | default (print $.RelPermalink .) | absURL }}"/>{{ end -}}
 {{- else -}}
 {{- $images := $.Resources.ByType "image" -}}
 {{- $featured := $images.GetMatch "*feature*" -}}


### PR DESCRIPTION
**What does this PR change? What problem does it solve?**

This allows referencing images in page bundles without having to put the whole path into the front-matter (which would break if the page moves or gets a custom slug).


**Was the change discussed in an issue or in the Discussions before?**

This came up when opengraph template was originally implemented ( https://github.com/adityatelange/hugo-PaperMod/issues/30 and https://github.com/adityatelange/hugo-PaperMod/issues/13, especially https://github.com/adityatelange/hugo-PaperMod/issues/30#issuecomment-706725646 )
## PR Checklist

- [ ] ~This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).~
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have verified that the code works as described/as intended.
- [ ] ~This change adds a Social Icon which has a permissive license to use it.~
- [x] This change **does not** include any CDN resources/links.
- [x] This change **does not** include any unrelated scripts such as bash and python scripts.
- [ ] This change updates the overridden internal templates from HUGO's repository.
