### PR TITLE
underline entry title on hover

### DIFF
--- a/assets/css/common/post-entry.css
+++ b/assets/css/common/post-entry.css
@@ -19,6 +19,10 @@
     line-height: 1.3;
 }
 
+.entry-link:hover ~ .entry-header {
+    text-decoration: underline;
+}
+
 .first-entry .entry-content {
     margin: 14px 0;
     font-size: 16px;

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -64,6 +64,7 @@
 {{- end }}
 
 <article class="{{ $class }}">
+  <a class="entry-link" aria-label="post link to {{ .Title | plainify }}" href="{{ .Permalink }}"></a>
   {{- $isHidden := (.Param "cover.hiddenInList") | default (.Param "cover.hidden") | default false }}
   {{- partial "cover.html" (dict "cxt" . "IsSingle" false "isHidden" $isHidden) }}
   <header class="entry-header">
@@ -89,7 +90,6 @@
     {{- partial "post_meta.html" . -}}
   </footer>
   {{- end }}
-  <a class="entry-link" aria-label="post link to {{ .Title | plainify }}" href="{{ .Permalink }}"></a>
 </article>
 {{- end }}
 


### PR DESCRIPTION
<!--

## READ BEFORE OPENING A PR

Thank you for contributing to hugo-PaperMod!
Please fill out the following questions to make it easier for us to review your
changes. You do not need to check all the boxes below.

**NOTE**: PaperMod does not have any external dependencies fetched from 3rd party
CDN servers. However we do have custom Head/Footer extender templates which you can use
to add those to your website.
https://github.com/adityatelange/hugo-PaperMod/wiki/FAQs#custom-head--footer

-->


**What does this PR change? What problem does it solve?**

`cursor: pointer` is intuitive when the whole entry is clickable.

with PR https://github.com/adityatelange/hugo-PaperMod/pull/1401 , it may happen that rendered summary contains a link. Then it becomes confusing which link is this: inner or outer.

Generally, it feels nice to have underlined links referring to clickable action. 
I suggest to underline the title of the entry, when mouse is over the link.

I suggest this change independently on the PR 1401.


**Was the change discussed in an issue or in the Discussions before?**

no

## PR Checklist

- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have verified that the code works as described/as intended.
- [ ] This change adds a Social Icon which has a permissive license to use it.
- [x] This change **does not** include any CDN resources/links.
- [x] This change **does not** include any unrelated scripts such as bash and python scripts.
- [ ] This change updates the overridden internal templates from HUGO's repository.
