### PR TITLE
add htmx option

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -6,6 +6,9 @@
 <html lang="{{ site.Language }}" dir="{{ .Language.LanguageDirection | default "auto" }}">
 
 <head>
+    {{ if site.Params.htmx }}
+        {{- partialCached "script-htmx.html" . -}}
+    {{ endif }}
     {{- partial "head.html" . }}
 </head>
 
@@ -16,7 +19,12 @@
 {{- if eq site.Params.defaultTheme `dark` -}}
 {{- print " dark" }}
 {{- end -}}
-" id="top">
+" id="top"
+{{- if site.Params.htmx -}}
+hx-boost="true" hx-push-url="true"
+{{- endif -}}
+
+>
     {{- partialCached "header.html" . .Page -}}
     <main class="main">
         {{- block "main" . }}{{ end }}

--- a/layouts/partials/script-htmx.html
+++ b/layouts/partials/script-htmx.html
@@ -1,0 +1,1 @@
+<script src="https://unpkg.com/htmx.org@1.9.10"></script>


### PR DESCRIPTION
<!--

## READ BEFORE OPENING A PR

Thank you for contributing to hugo-PaperMod!
Please fill out the following questions to make it easier for us to review your
changes. You do not need to check all the boxes below.

**NOTE**: PaperMod does not have any external dependencies fetched from 3rd party
CDN servers. However we do have custom Head/Footer extender templates which you can use
to add those to your website.
https://github.com/adityatelange/hugo-PaperMod/wiki/FAQs#custom-head--footer

-->


**What does this PR change? What problem does it solve?**

I've used turbolinks previously to give that SPA feel to a static site but turbolinks is basically dead.

Today we can achieve the same behaviour using hx-boost from HTMX. This PR adds a simple option to enable that
and a overridable partial to override where the site gets their HTMX bundle.

Vendoring is possible if desirable as HTMX has a permissive enough license to embed without even needing attribution.

<!--
Describe the changes and their purpose here, as detailed as and if  needed.

Please do not add 2 unrelated changes in a single PR as it is difficult to track/revert those in future.
-->


**Was the change discussed in an issue or in the Discussions before?**

<!--
Link issues and relevant Discussions posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->


## PR Checklist

- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have verified that the code works as described/as intended.
- [ ] This change adds a Social Icon which has a permissive license to use it.
- [ ] This change **does not** include any CDN resources/links.
- [x] This change **does not** include any unrelated scripts such as bash and python scripts.
- [ ] This change updates the overridden internal templates from HUGO's repository.
