### PR TITLE
Add demosite for "Demo" button on themes.gohugo.io

### DIFF
--- a/theme.toml
+++ b/theme.toml
@@ -6,6 +6,7 @@ license = "MIT"
 licenselink = "https://github.com/adityatelange/hugo-PaperMod/blob/master/LICENSE"
 description = "A fast, clean, responsive Hugo theme"
 homepage = "https://adityatelange.github.io/hugo-PaperMod/"
+demosite = "https://adityatelange.github.io/hugo-PaperMod/"
 tags = [
   "responsive",
   "simple",


### PR DESCRIPTION
**What does this PR change? What problem does it solve?**

At https://themes.gohugo.io/themes/hugo-papermod/ there is no direct link to the demo site. This PR adds the demosite variable (idk what its called) in theme.toml, which is necessary for the "Demo" button. See https://github.com/gohugoio/hugoThemesSiteBuilder#theme-configuration.

## PR Checklist

- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have verified that the code works as described/as intended.
- [ ] This change adds a Social Icon which has a permissive license to use it.
- [x] This change **does not** include any CDN resources/links.
- [x] This change **does not** include any unrelated scripts such as bash and python scripts.
- [x] This change updates the overridden internal templates from HUGO's repository.
