### PR TITLE
Fix hugo build fail due to "expected comma" error

### DIFF
--- a/layouts/partials/templates/schema_json.html
+++ b/layouts/partials/templates/schema_json.html
@@ -83,7 +83,7 @@
   {{- else }}
     {{- $images := partial "partials/templates/_funcs/get-page-images" . -}}
     {{- with index $images 0 -}}
-  "image": {{ .Permalink }}
+  "image": {{ .Permalink }},
     {{- end }}
   {{- end -}}
   "datePublished": {{ .PublishDate }},


### PR DESCRIPTION
<!--

## READ BEFORE OPENING A PR

Thank you for contributing to hugo-PaperMod!
Please fill out the following questions to make it easier for us to review your
changes. You do not need to check all the boxes below.

**NOTE**: PaperMod does not have any external dependencies fetched from 3rd party
CDN servers. However we do have custom Head/Footer extender templates which you can use
to add those to your website.
https://github.com/adityatelange/hugo-PaperMod/wiki/FAQs#custom-head--footer

-->


**What does this PR change? What problem does it solve?**

<!--
Describe the changes and their purpose here, as detailed as and if  needed.

Please do not add 2 unrelated changes in a single PR as it is difficult to track/revert those in future.
-->
This PR fixes the `hugo` build fails due to not having an expected comma in the `schema_json` template.

**Was the change discussed in an issue or in the Discussions before?**

<!--
Link issues and relevant Discussions posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->
Fixes adityatelange/hugo-PaperMod#1458

## PR Checklist

- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have verified that the code works as described/as intended.
- [ ] This change adds a Social Icon which has a permissive license to use it.
- [x] This change **does not** include any CDN resources/links.
- [x] This change **does not** include any unrelated scripts such as bash and python scripts.
- [x] This change updates the overridden internal templates from HUGO's repository.
