### PR TITLE
fix(html): remove trailing slash on void elements

### DIFF
--- a/layouts/partials/templates/opengraph.html
+++ b/layouts/partials/templates/opengraph.html
@@ -1,33 +1,33 @@
-<meta property="og:title" content="{{ .Title }}" />
-<meta property="og:description" content="{{ with .Description }}{{ . }}{{ else }}{{if .IsPage}}{{ .Summary }}{{ else }}{{ with site.Params.description }}{{ . }}{{ end }}{{ end }}{{ end }}" />
-<meta property="og:type" content="{{ if .IsPage }}article{{ else }}website{{ end }}" />
-<meta property="og:url" content="{{ .Permalink }}" />
+<meta property="og:title" content="{{ .Title }}">
+<meta property="og:description" content="{{ with .Description }}{{ . }}{{ else }}{{if .IsPage}}{{ .Summary }}{{ else }}{{ with site.Params.description }}{{ . }}{{ end }}{{ end }}{{ end }}">
+<meta property="og:type" content="{{ if .IsPage }}article{{ else }}website{{ end }}">
+<meta property="og:url" content="{{ .Permalink }}">
 {{- if .Params.cover.image -}}
 {{- if (ne .Params.cover.relative true) }}
-<meta property="og:image" content="{{ .Params.cover.image | absURL }}" />
+<meta property="og:image" content="{{ .Params.cover.image | absURL }}">
 {{- else}}
-<meta property="og:image" content="{{ (path.Join .RelPermalink .Params.cover.image ) | absURL }}" />
+<meta property="og:image" content="{{ (path.Join .RelPermalink .Params.cover.image ) | absURL }}">
 {{- end}}
 {{- else }}
 
 {{- $images := partial "partials/templates/_funcs/get-page-images" . -}}
 {{- range first 6 $images }}
-<meta property="og:image" content="{{ .Permalink }}" />
+<meta property="og:image" content="{{ .Permalink }}">
 {{ end -}}
 {{- end }}
 
 {{- if .IsPage }}
 {{- $iso8601 := "2006-01-02T15:04:05-07:00" -}}
-<meta property="article:section" content="{{ .Section }}" />
-{{ with .PublishDate }}<meta property="article:published_time" {{ .Format $iso8601 | printf "content=%q" | safeHTMLAttr }} />{{ end }}
-{{ with .Lastmod }}<meta property="article:modified_time" {{ .Format $iso8601 | printf "content=%q" | safeHTMLAttr }} />{{ end }}
+<meta property="article:section" content="{{ .Section }}">
+{{ with .PublishDate }}<meta property="article:published_time" {{ .Format $iso8601 | printf "content=%q" | safeHTMLAttr }}>{{ end }}
+{{ with .Lastmod }}<meta property="article:modified_time" {{ .Format $iso8601 | printf "content=%q" | safeHTMLAttr }}>{{ end }}
 {{- end -}}
 
-{{- with .Params.audio }}<meta property="og:audio" content="{{ . }}" />{{ end }}
-{{- with .Params.locale }}<meta property="og:locale" content="{{ . }}" />{{ end }}
-{{- with site.Params.title }}<meta property="og:site_name" content="{{ . }}" />{{ end }}
+{{- with .Params.audio }}<meta property="og:audio" content="{{ . }}">{{ end }}
+{{- with .Params.locale }}<meta property="og:locale" content="{{ . }}">{{ end }}
+{{- with site.Params.title }}<meta property="og:site_name" content="{{ . }}">{{ end }}
 {{- with .Params.videos }}{{- range . }}
-<meta property="og:video" content="{{ . | absURL }}" />
+<meta property="og:video" content="{{ . | absURL }}">
 {{ end }}{{ end }}
 
 {{- /* If it is part of a series, link to related articles */}}
@@ -37,7 +37,7 @@
 {{ with .Params.series }}{{- range $name := . }}
   {{- $series := index $siteSeries ($name | urlize) }}
   {{- range $page := first 6 $series.Pages }}
-    {{- if ne $page.Permalink $permalink }}<meta property="og:see_also" content="{{ $page.Permalink }}" />{{ end }}
+    {{- if ne $page.Permalink $permalink }}<meta property="og:see_also" content="{{ $page.Permalink }}">{{ end }}
   {{- end }}
 {{ end }}{{ end }}
 {{- end }}
@@ -56,4 +56,4 @@
 {{- end }}
 
 {{- /* Facebook Page Admin ID for Domain Insights */}}
-{{ with $facebookAdmin }}<meta property="fb:admins" content="{{ . }}" />{{ end }}
+{{ with $facebookAdmin }}<meta property="fb:admins" content="{{ . }}">{{ end }}

--- a/layouts/partials/templates/twitter_cards.html
+++ b/layouts/partials/templates/twitter_cards.html
@@ -1,21 +1,21 @@
 {{- if .Params.cover.image -}}
-<meta name="twitter:card" content="summary_large_image" />
+<meta name="twitter:card" content="summary_large_image">
 {{- if (ne $.Params.cover.relative true) }}
-<meta name="twitter:image" content="{{ .Params.cover.image | absURL }}" />
+<meta name="twitter:image" content="{{ .Params.cover.image | absURL }}">
 {{- else }}
-<meta name="twitter:image" content="{{ (path.Join .RelPermalink .Params.cover.image ) | absURL }}" />
+<meta name="twitter:image" content="{{ (path.Join .RelPermalink .Params.cover.image ) | absURL }}">
 {{- end}}
 {{- else }}
 {{- $images := partial "partials/templates/_funcs/get-page-images" . -}}
 {{- with index $images 0 -}}
-<meta name="twitter:card" content="summary_large_image" />
-<meta name="twitter:image" content="{{ .Permalink }}" />
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:image" content="{{ .Permalink }}">
 {{- else -}}
-<meta name="twitter:card" content="summary"/>
+<meta name="twitter:card" content="summary">
 {{- end -}}
 {{- end }}
-<meta name="twitter:title" content="{{ .Title }}"/>
-<meta name="twitter:description" content="{{ with .Description }}{{ . }}{{ else }}{{if .IsPage}}{{ .Summary }}{{ else }}{{ with site.Params.description }}{{ . }}{{ end }}{{ end }}{{ end -}}"/>
+<meta name="twitter:title" content="{{ .Title }}">
+<meta name="twitter:description" content="{{ with .Description }}{{ . }}{{ else }}{{if .IsPage}}{{ .Summary }}{{ else }}{{ with site.Params.description }}{{ . }}{{ end }}{{ end }}{{ end -}}">
 {{- /* Deprecate site.Social.twitter in favor of site.Params.social.twitter */}}
 {{- $twitterSite := "" }}
 {{- with site.Params.social }}
@@ -34,5 +34,5 @@
   {{- if not (strings.HasPrefix . "@") }}
     {{- $content = printf "@%v" $twitterSite }}
   {{- end }}
-<meta name="twitter:site" content="{{ $content }}"/>
+<meta name="twitter:site" content="{{ $content }}">
 {{- end }}


### PR DESCRIPTION
**What does this PR change? What problem does it solve?**

Remove trailing slash on void elements.
https://developer.mozilla.org/en-US/docs/Glossary/Void_element

**Was the change discussed in an issue or in the Discussions before?**

fixes #1469 

## PR Checklist

- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have verified that the code works as described/as intended.
- [ ] This change adds a Social Icon which has a permissive license to use it.
- [x] This change **does not** include any CDN resources/links.
- [x] This change **does not** include any unrelated scripts such as bash and python scripts.
- [ ] This change updates the overridden internal templates from HUGO's repository.
