### PR TITLE
Added a "categories" page for further categorization

### DIFF
--- a/assets/css/common/categories.css
+++ b/assets/css/common/categories.css
@@ -1,0 +1,30 @@
+/* Setup grid for Categories */
+.categories {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: var(--gap);
+}
+
+/* Setup grid on mobile */
+@media (max-width: 480px) {
+  .categories {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+/* CSS for Category Blocks */
+.category-entry {
+  position: relative;
+  background: var(--entry);
+  border-radius: var(--radius);
+  transition: transform 0.1s;
+  padding: 20px 30px;
+}
+
+/* Increase size slightly on hover */
+.category-entry:hover {
+  transform: scale(1.04);
+}
+.category-entry:active {
+  transform: scale(1);
+}

--- a/layouts/_default/categories.html
+++ b/layouts/_default/categories.html
@@ -1,0 +1,58 @@
+{{- define "main" }}
+
+{{- if .Title }}
+<header class="page-header">
+    {{- partial "breadcrumbs.html" . }}
+    <h1>
+        {{ .Title }}
+        {{- if and (or (eq .Kind `taxonomy`) (eq .Kind `section`)) (.Param "ShowRssButtonInSectionTermList") }}
+        <a href="index.xml" title="RSS" aria-label="RSS">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+            stroke-linecap="round" stroke-linejoin="round" height="23">
+            <path d="M4 11a9 9 0 0 1 9 9" />
+            <path d="M4 4a16 16 0 0 1 16 16" />
+            <circle cx="5" cy="19" r="1" />
+        </svg>
+        </a>
+        {{- end }}
+    </h1>
+    {{- if .Description }}
+    <div class="post-description">
+        {{ .Description }}
+    </div>
+    {{- end }}
+</header>
+{{- end }}
+
+{{- if .Content }}
+<div class="post-content">
+  {{- if not (.Param "disableAnchoredHeadings") }}
+  {{- partial "anchored_headings.html" .Content -}}
+  {{- else }}{{ .Content }}{{ end }}
+</div>
+{{- end }}
+
+<div class="categories">
+{{- $type := .Type }}
+{{- range $key, $value := .Data.Terms.Alphabetical }}
+{{- $name := .Name }}
+{{- $count := .Count }}
+{{- with site.GetPage (printf "/%s/%s" $type $name) }}
+<div class="category-entry">
+    <header class="entry-header">
+        <h2>{{- .Name }} <sup style="font-size:10pt">{{ $count }}</sup></h2>
+    </header>
+    {{- if (ne (.Param "hideSummary") true) }}
+    
+    <div class="entry-content">
+        <p>{{ .Summary | plainify | htmlUnescape }}{{ if .Truncated }}...{{ end }}</p>
+    </div>
+    {{- end }}
+    
+    <a class="entry-link" aria-label="post link to {{ .Title | plainify }}" href="{{ .Permalink }}"></a>
+</div>
+{{- end }}
+{{- end }}
+</div>
+
+{{- end }}{{/* end main */ -}}


### PR DESCRIPTION
**What does this PR change? What problem does it solve?**
Creates a new tab for "categories". This allows users to have groupings of posts (sort of like a folder) that can be navigated, rather than having to go through the "posts" tab or the "tags" tab. 

Users simply create a folder called "categories" under "content". The `_index.md` file within the "categories" folder will be used to configure that page. 

For creating each category page, just create folders (and their `_index.md` files) within the "categories" folder like so:

```
content
└── categories
│  └────  foo/ 
│  │  └────  _index.md  
│  └────  bar/ 
│  │  └────  _index.md  
│  └────  foobar/ 
│  │  └────  _index.md  
│  └────  _index.md 
```

Posts can be assigned to categories just as they would be for tags or keywords:

```
---
title: 'Example Post'
categories: ["PRs"]
tags: ["new thing"]
keywords: []
---
```

**Was the change discussed in an issue or in the Discussions before?**
No


## PR Checklist

- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have verified that the code works as described/as intended.
- [ ] This change adds a Social Icon which has a permissive license to use it.
- [x] This change **does not** include any CDN resources/links.
- [x] This change **does not** include any unrelated scripts such as bash and python scripts.
- [ ] This change updates the overridden internal templates from HUGO's repository.
