### PR TITLE
Allow Markdown in all Description params

### DIFF
--- a/layouts/_default/archives.html
+++ b/layouts/_default/archives.html
@@ -22,7 +22,7 @@
   </h1>
   {{- if .Description }}
   <div class="post-description">
-    {{ .Description }}
+    {{ .Description | markdownify }}
   </div>
   {{- end }}
 </header>

--- a/layouts/_default/search.html
+++ b/layouts/_default/search.html
@@ -10,7 +10,7 @@
     </h1>
     {{- if .Description }}
     <div class="post-description">
-        {{ .Description }}
+        {{ .Description | markdownify }}
     </div>
     {{- end }}
     {{- if not (.Param "hideMeta") }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -16,7 +16,7 @@
     </h1>
     {{- if .Description }}
     <div class="post-description">
-      {{ .Description }}
+      {{ .Description | markdownify }}
     </div>
     {{- end }}
     {{- if not (.Param "hideMeta") }}

--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -5,7 +5,7 @@
     <h1>{{ .Title }}</h1>
     {{- if .Description }}
     <div class="post-description">
-        {{ .Description }}
+        {{ .Description | markdownify }}
     </div>
     {{- end }}
 </header>


### PR DESCRIPTION
**What does this PR change? What problem does it solve?**
This commit allows markdown in the Description param for single posts, archives page, tags page, and the search page. This is really useful for hyperlinking to pages the post is about. 

**Was the change discussed in an issue or in the Discussions before?**
No

## PR Checklist

- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have verified that the code works as described/as intended.
- [ ] This change adds a Social Icon which has a permissive license to use it.
- [x] This change **does not** include any CDN resources/links.
- [x] This change **does not** include any unrelated scripts such as bash and python scripts.
- [ ] This change updates the overridden internal templates from HUGO's repository.
