### PR TITLE
Remove disableHLJS from FAQ

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -184,7 +184,6 @@ params:
   #         SiteVerificationTag: "XYZabc"
 
   assets:
-    disableHLJS: true
   #     favicon: "<link / abs url>"
   #     favicon16x16: "<link / abs url>"
   #     favicon32x32: "<link / abs url>"

--- a/content/posts/papermod/papermod-faq.md
+++ b/content/posts/papermod/papermod-faq.md
@@ -243,15 +243,7 @@ use `align=center` to center image with captions
 
 ## Using Hugo's Syntax highlighter "chroma"
 
-1. Disable Highlight.js in site `config.yml`
-
-   ```yml {linenos=true}
-   params:
-     assets:
-       disableHLJS: true
-   ```
-
-2. Set hugo's markdown styling in site `config.yml`
+1. Set hugo's markdown styling in site `config.yml`
 
    ```yml {linenos=true}
    markup:
@@ -264,7 +256,7 @@ use `align=center` to center image with captions
        style: monokai
    ```
 
-3. If you want `lineNos: true`, the background won't be proper.
+2. If you want `lineNos: true`, the background won't be proper.
    This will only work with `noClasses: false` or `pygmentsUseClasses: true`.
    Read [Generate Syntax Highlighter CSS](https://gohugo.io/content-management/syntax-highlighting/#generate-syntax-highlighter-css)
 


### PR DESCRIPTION

<!--

## READ BEFORE OPENING A PR

Thank you for contributing to hugo-PaperMod!
Please fill out the following questions to make it easier for us to review your
changes. You do not need to check all the boxes below.

**NOTE**: PaperMod does not have any external dependencies fetched from 3rd party
CDN servers. However we do have custom Head/Footer extender templates which you can use
to add those to your website.
https://github.com/adityatelange/hugo-PaperMod/wiki/FAQs#custom-head--footer

-->


**What does this PR change? What problem does it solve?**

HLJS support seems having been removed from this theme already. `disableHLJS` doesn't do anything.


**Was the change discussed in an issue or in the Discussions before?**

No


## PR Checklist

- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have verified that the code works as described/as intended.
- [ ] This change adds a Social Icon which has a permissive license to use it.
- [x] This change **does not** include any CDN resources/links.
- [x] This change **does not** include any unrelated scripts such as bash and python scripts.
- [ ] This change updates the overridden internal templates from HUGO's repository.
