### PR TITLE
Add ethereum social icon

### DIFF
--- a/layouts/partials/svg.html
+++ b/layouts/partials/svg.html
@@ -229,6 +229,10 @@
     <path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"></path>
     <polyline points="22,6 12,13 2,6"></polyline>
 </svg>
+{{- else if (eq $icon_name "ethereum") -}}
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+    <path d="M11.944 17.97L4.58 13.62 11.943 24l7.37-10.38-7.372 4.35h.003zM12.056 0L4.69 12.223l7.365 4.354 7.365-4.35L12.056 0z"/>
+</svg>
 {{- else if (eq $icon_name "exercism") -}}
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2230.4 1817.9" fill="currentColor" stroke-width="2" stroke="currentColor">
 <path d="M0,905.1v-48.3c119-10.6,189.5-56.6,206.8-157.4c14.8-85.8-9.8-249.3-6.7-387.8c3.5-157,107.1-289.2,222.6-305.8


### PR DESCRIPTION
**What does this PR change? What problem does it solve?**

Similar to #748, this adds a popular cryptocurrency icon used for donations by podcasters and others. Icon source is simpleicons.org and icon has been tested to work properly.


**Was the change discussed in an issue or in the Discussions before?**

No.


## PR Checklist

- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have verified that the code works as described/as intended.
- [x] This change adds a Social Icon which has a permissive license to use it.
- [x] This change **does not** include any CDN resources/links.
- [x] This change **does not** include any unrelated scripts such as bash and python scripts.
- [ ] This change updates the overridden internal templates from HUGO's repository.
