### PR TITLE
Added umami analytics support

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -151,6 +151,7 @@
 {{- /* Misc */}}
 {{- if hugo.IsProduction | or (eq site.Params.env "production") }}
 {{- template "_internal/google_analytics.html" . }}
+{{- template "partials/templates/umami.html" . }}
 {{- template "partials/templates/opengraph.html" . }}
 {{- template "partials/templates/twitter_cards.html" . }}
 {{- template "partials/templates/schema_json.html" . }}

--- a/layouts/partials/templates/umami.html
+++ b/layouts/partials/templates/umami.html
@@ -1,0 +1,2 @@
+{{ if site.Params.analytics.umami }}<script defer src="{{ site.Params.analytics.umami.url }}" data-website-id="{{ site.Params.analytics.umami.id }}"></script>
+{{ end }}


### PR DESCRIPTION
**What does this PR change? What problem does it solve?**

This PR adds umami analytics support (https://umami.is/), the user can add the id and url of their installation to analytics and activate the tracking code.

it can be achieved with 

```
params:
      analytics:
          umami:
              id: ID_CODE  #provided on umami backoffice
              url: URL  #for example https://eu.umami.is/script.js

````

This will add the appropriate code as it can be viewed on my website which is already using this change live:

https://github.com/DJLink/web_david-amador.com/blob/9234c4cfb7935c224abc123dad83a59ff7a7ec5e/index.html#L31

**Was the change discussed in an issue or in the Discussions before?**
No


## PR Checklist

- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have verified that the code works as described/as intended.
- [ ] This change adds a Social Icon which has a permissive license to use it.
- [x] This change **does not** include any CDN resources/links.
- [x] This change **does not** include any unrelated scripts such as bash and python scripts.
- [x] This change updates the overridden internal templates from HUGO's repository.
