### PR TITLE
feat: if site configuration for disqus is set, use hugo embedded disq…

### DIFF
--- a/layouts/partials/comments.html
+++ b/layouts/partials/comments.html
@@ -1,3 +1,6 @@
 {{- /* Comments area start */ -}}
 {{- /* to add comments read => https://gohugo.io/content-management/comments/ */ -}}
+{{- if site.Config.Services.Disqus.Shortname }}
+{{ template "_internal/disqus.html" . }}
+{{- end}}
 {{- /* Comments area end */ -}}


### PR DESCRIPTION
…us template

**What does this PR change? What problem does it solve?**

enable disqus comment function when user configured to use it

**Was the change discussed in an issue or in the Discussions before?**
as long as I found, no.

## PR Checklist

- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have verified that the code works as described/as intended.
- [ ] This change adds a Social Icon which has a permissive license to use it.
- [x] This change **does not** include any CDN resources/links.
- [x] This change **does not** include any unrelated scripts such as bash and python scripts.
- [ ] This change updates the overridden internal templates from HUGO's repository.
