### PR TITLE
feat: if site param has show all pages in home option, then home rend…

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -42,6 +42,11 @@
 
 {{- if .IsHome }}
 {{- $pages = where site.RegularPages "Type" "in" site.Params.mainSections }}
+
+{{- if site.Params.ShowAllPagesInHome }}
+{{- $pages = site.RegularPages }}
+{{- end }}
+
 {{- $pages = where $pages "Params.hiddenInHomeList" "!=" "true"  }}
 {{- end }}
 


### PR DESCRIPTION
…er all pages

**What does this PR change? What problem does it solve?**
in index page, there isn't function to add all pages.
if user set site.params.ShowAllPagesInHome as true, then use $page as site.RegularPages

**Was the change discussed in an issue or in the Discussions before?**
as long as I find, no.

## PR Checklist

- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have verified that the code works as described/as intended.
- [ ] This change adds a Social Icon which has a permissive license to use it.
- [x] This change **does not** include any CDN resources/links.
- [x] This change **does not** include any unrelated scripts such as bash and python scripts.
- [ ] This change updates the overridden internal templates from HUGO's repository.
