### PR TITLE
When display post summary, use .Summary instead of .Description

### DIFF
--- a/assets/css/common/post-single.css
+++ b/assets/css/common/post-single.css
@@ -8,7 +8,7 @@
     font-size: 40px;
 }
 
-.post-description {
+.post-summary {
     margin-top: 10px;
     margin-bottom: 5px;
 }

--- a/layouts/_default/archives.html
+++ b/layouts/_default/archives.html
@@ -20,9 +20,9 @@
     {{- end }}
     {{- end }}
   </h1>
-  {{- if .Description }}
-  <div class="post-description">
-    {{ .Description }}
+  {{- if .Summary }}
+  <div class="post-summary">
+    {{ .Summary }}
   </div>
   {{- end }}
 </header>

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -22,9 +22,9 @@
     {{- end }}
     {{- end }}
   </h1>
-  {{- if .Description }}
-  <div class="post-description">
-    {{ .Description | markdownify }}
+  {{- if .Summary }}
+  <div class="post-summary">
+    {{ .Summary | markdownify }}
   </div>
   {{- end }}
 </header>

--- a/layouts/_default/search.html
+++ b/layouts/_default/search.html
@@ -8,9 +8,9 @@
             <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
         </svg>
     </h1>
-    {{- if .Description }}
-    <div class="post-description">
-        {{ .Description }}
+    {{- if .Summary }}
+    <div class="post-summary">
+        {{ .Summary }}
     </div>
     {{- end }}
     {{- if not (.Param "hideMeta") }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -14,9 +14,9 @@
       </span>
       {{- end }}
     </h1>
-    {{- if .Description }}
-    <div class="post-description">
-      {{ .Description }}
+    {{- if .Summary }}
+    <div class="post-summary">
+      {{ .Summary }}
     </div>
     {{- end }}
     {{- if not (.Param "hideMeta") }}

--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -3,9 +3,9 @@
 {{- if .Title }}
 <header class="page-header">
     <h1>{{ .Title }}</h1>
-    {{- if .Description }}
-    <div class="post-description">
-        {{ .Description }}
+    {{- if .Summary }}
+    <div class="post-summary">
+        {{ .Summary }}
     </div>
     {{- end }}
 </header>


### PR DESCRIPTION
.Description is meant to be used for metadata purpose: https://gohugo.io/methods/page/description/
While .Summary can be used to display to human readers: https://gohugo.io/methods/page/summary/

Hugo document has emphasized this in the .Description page:

> Conceptually different from a content summary, a page description is typically used in metadata about the page.

Hugo embedded templates are consistent in this regard.

<!--

## READ BEFORE OPENING A PR

Thank you for contributing to hugo-PaperMod!
Please fill out the following questions to make it easier for us to review your
changes. You do not need to check all the boxes below.

**NOTE**: PaperMod does not have any external dependencies fetched from 3rd party
CDN servers. However we do have custom Head/Footer extender templates which you can use
to add those to your website.
https://github.com/adityatelange/hugo-PaperMod/wiki/FAQs#custom-head--footer

-->

## PR Checklist

- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have verified that the code works as described/as intended.
- [ ] This change adds a Social Icon which has a permissive license to use it.
- [x] This change **does not** include any CDN resources/links.
- [x] This change **does not** include any unrelated scripts such as bash and python scripts.
- [ ] This change updates the overridden internal templates from HUGO's repository.
