### PR TITLE
feat: Add option to use GoatCounter analytics

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -29,6 +29,9 @@
 {{- if site.Params.analytics.yandex.SiteVerificationTag }}
 <meta name="yandex-verification" content="{{ site.Params.analytics.yandex.SiteVerificationTag }}">
 {{- end }}
+{{- if site.Params.analytics.goatcounter.Code }}
+<script data-goatcounter="https://{{site.Params.analytics.goatcounter.Code}}.goatcounter.com/count" async src="{{ if site.Params.analytics.goatcounter.Src }}{{ site.Params.analytics.goatcounter.Src }}{{ else }}//gc.zgo.at/count.js{{ end }}"></script>
+{{- end }}
 {{- if site.Params.analytics.bing.SiteVerificationTag }}
 <meta name="msvalidate.01" content="{{ site.Params.analytics.bing.SiteVerificationTag }}">
 {{- end }}


### PR DESCRIPTION
I learned about [GoatCounter](https://www.goatcounter.com/) a while ago and wanted to implement it on my site running PaperMod. GoatCounter provides open-source, privacy-friendly web analytics and can be self-hosted. I added three lines to `layouts/partials/head.html` and it works.

The script, `count.js`, can also be hosted as a simple JS file. In my case, I wanted to have it in `static/`. I added `site.Params.analytics.goatcounter.Src` which can be used to override the default mirror.
The "code" (similar to a site verification tag) can be set via `site.Params.analytics.goatcounter.Code`.

I'm not sure if this goes against the PR policy of "not [including] any CDN resources/links" since it optionally uses the GoatCounter script.