### PR TITLE
Improve date formatting with explicit safeHTML

### DIFF
--- a/layouts/partials/post_meta.html
+++ b/layouts/partials/post_meta.html
@@ -1,23 +1,27 @@
 {{- $scratch := newScratch }}
 
 {{- if not .Date.IsZero -}}
-{{- $scratch.Add "meta" (slice (printf "<span title='%s'>%s</span>" (.Date) (.Date | time.Format (default "January 2, 2006" site.Params.DateFormat)))) }}
+  {{- $date := printf "<span title='%s'>%s</span>" (.Date) (.Date | time.Format (default "January 2, 2006" site.Params.DateFormat)) | safeHTML }}
+  {{- $scratch.Add "meta" (slice $date) }}
 {{- end }}
 
 {{- if (.Param "ShowReadingTime") -}}
-{{- $scratch.Add "meta" (slice (i18n "read_time" .ReadingTime | default (printf "%d min" .ReadingTime))) }}
+  {{- $readingTime := i18n "read_time" .ReadingTime | default (printf "%d min" .ReadingTime) | safeHTML }}
+  {{- $scratch.Add "meta" (slice $readingTime) }}
 {{- end }}
 
 {{- if (.Param "ShowWordCount") -}}
-{{- $scratch.Add "meta" (slice (i18n "words" .WordCount | default (printf "%d words" .WordCount))) }}
+  {{- $wordCount := i18n "words" .WordCount | default (printf "%d words" .WordCount) | safeHTML }}
+  {{- $scratch.Add "meta" (slice $wordCount) }}
 {{- end }}
 
 {{- if not (.Param "hideAuthor") -}}
-{{- with (partial "author.html" .) }}
-{{- $scratch.Add "meta" (slice .) }}
-{{- end }}
+  {{- with (partial "author.html" .) }}
+    {{- $author := . | safeHTML }}
+    {{- $scratch.Add "meta" (slice $author) }}
+  {{- end }}
 {{- end }}
 
 {{- with ($scratch.Get "meta") }}
-{{- delimit . "&nbsp;·&nbsp;" | safeHTML -}}
+  {{- delimit . "&nbsp;·&nbsp;" | safeHTML }}
 {{- end -}}


### PR DESCRIPTION
<!--

## READ BEFORE OPENING A PR

Thank you for contributing to hugo-PaperMod!
Please fill out the following questions to make it easier for us to review your
changes. You do not need to check all the boxes below.

**NOTE**: PaperMod does not have any external dependencies fetched from 3rd party
CDN servers. However we do have custom Head/Footer extender templates which you can use
to add those to your website.
https://github.com/adityatelange/hugo-PaperMod/wiki/FAQs#custom-head--footer

-->


**What does this PR change? What problem does it solve?**
This PR improves the previous fix for the date formatting issue in the development environment by explicitly using `safeHTML` for each metadata component. This ensures that all metadata, including the date, reading time, word count, and author, is correctly formatted and rendered without HTML entities being escaped.

<!--
Describe the changes and their purpose here, as detailed as and if  needed.


Please do not add 2 unrelated changes in a single PR as it is difficult to track/revert those in future.
-->


**Was the change discussed in an issue or in the Discussions before?**
This PR is related to [Issue #1344](https://github.com/adityatelange/hugo-PaperMod/issues/1344), which addressed the initial problem of escaped HTML in the post metadata. This PR enhances the solution to ensure comprehensive and explicit handling of HTML content.
<!--
Link issues and relevant Discussions posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->


## PR Checklist

- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [ ] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have verified that the code works as described/as intended.
- [ ] This change adds a Social Icon which has a permissive license to use it.
- [ ] This change **does not** include any CDN resources/links.
- [ ] This change **does not** include any unrelated scripts such as bash and python scripts.
- [ ] This change updates the overridden internal templates from HUGO's repository.
