### PR TITLE
fix(css): post header margin on mobile

### DIFF
--- a/assets/css/common/post-single.css
+++ b/assets/css/common/post-single.css
@@ -1,6 +1,6 @@
 .page-header,
 .post-header {
-    margin: 24px auto var(--content-gap) auto;
+    margin: var(--gap) auto var(--content-gap) auto;
 }
 
 .post-title {


### PR DESCRIPTION
**What does this PR change? What problem does it solve?**

On mobile, the spacing between the page header and the post title feels too big. I guessed this is caused by the use of hard-coded `24px` on `margin-top` instead of the `--gap` variable, whose value is `24px` by default but get down to `14px` on smaller screens and mobile.

See the difference on the theme Install page:
| Before | After |
| --- | --- |
| ![Capture d’écran du 2024-07-11 14-30-58](https://github.com/adityatelange/hugo-PaperMod/assets/1136694/304c94f4-a98f-4a36-987a-6633d1fcc063) | ![Capture d’écran du 2024-07-11 14-31-15](https://github.com/adityatelange/hugo-PaperMod/assets/1136694/07fe282a-d61a-475b-95a6-cd5fa4201466)|



**Was the change discussed in an issue or in the Discussions before?**

Clearly not :grimacing: 

## PR Checklist

- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have verified that the code works as described/as intended.
- [ ] This change adds a Social Icon which has a permissive license to use it.
- [x] This change **does not** include any CDN resources/links.
- [x] This change **does not** include any unrelated scripts such as bash and python scripts.
- [ ] This change updates the overridden internal templates from HUGO's repository.
