### PR TITLE
[FEATURE] optional special treatment for external links

### DIFF
--- a/assets/css/common/post-single.css
+++ b/assets/css/common/post-single.css
@@ -82,6 +82,46 @@
     box-shadow: 0 -1px 0 var(--primary) inset;
 }
 
+.post-content a.external-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+}
+
+.post-content a.external-link::after {
+  content: "";
+  display: inline-block;
+  clip-path: polygon(
+    60% 5%,
+    60% 0%,
+    100% 0%,
+    100% 5%,
+    100% 40%,
+    94.98% 40%,
+    94.98% 5%,
+    94.98% 9.59%,
+    42.41% 59.2%,
+    38.1% 54.64%,
+    90.7% 5%,
+    60% 5%,
+    50% 8%,
+    13% 8%,
+    8% 8%,
+    8% 92%,
+    92% 92%,
+    92% 50%,
+    87% 50%,
+    87% 87%,
+    13% 87%,
+    13% 13%,
+    50% 13%,
+    50% 8%
+  );
+  background-color: var(--primary);
+  width: 18px;
+  height: 18px;
+}
+
 .post-content del {
     text-decoration: line-through;
 }

--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -1,0 +1,4 @@
+<a href="{{ .Destination | safeURL }}"{{ with .Title}} title="{{ . }}"{{ end }}
+   {{ if and site.Params.ExternalLinksIcon (strings.HasPrefix .Destination "http") }} class="external-link"{{ end }}
+   {{ if and site.Params.ExternalLinksNewTab (strings.HasPrefix .Destination "http") }} target="_blank"{{ end }}
+>{{ .Text }}</a>


### PR DESCRIPTION
**What does this PR change? What problem does it solve?**

This PR proposes a way to optionally open external links to a new tab, and optionally mark external links with an icon.

**Was the change discussed in an issue or in the Discussions before?**

I just opened #1612 to make a rationale about this.

## PR Checklist

- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have verified that the code works as described/as intended.
- [ ] This change adds a Social Icon which has a permissive license to use it.
- [x] This change **does not** include any CDN resources/links.
- [x] This change **does not** include any unrelated scripts such as bash and python scripts.
- [x] This change updates the overridden internal templates from HUGO's repository.
