### PR TITLE
:bug: Fix CSS/JS URLs reference to support deployment in a subdirectory

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -69,9 +69,9 @@
 
 {{- if not site.Params.assets.disableFingerprinting }}
 {{- $stylesheet := $stylesheet | fingerprint }}
-<link crossorigin="anonymous" href="{{ $stylesheet.RelPermalink }}" integrity="{{ $stylesheet.Data.Integrity }}" rel="preload stylesheet" as="style">
+<link crossorigin="anonymous" href="{{ $stylesheet.RelPermalink | absURL }}" integrity="{{ $stylesheet.Data.Integrity }}" rel="preload stylesheet" as="style">
 {{- else }}
-<link crossorigin="anonymous" href="{{ $stylesheet.RelPermalink }}" rel="preload stylesheet" as="style">
+<link crossorigin="anonymous" href="{{ $stylesheet.RelPermalink | absURL }}" rel="preload stylesheet" as="style">
 {{- end }}
 
 {{- /* Search */}}
@@ -82,10 +82,10 @@
 {{- $license_js := resources.Get "js/license.js" }}
 {{- if not site.Params.assets.disableFingerprinting }}
 {{- $search := (slice $fusejs $license_js $fastsearch ) | resources.Concat "assets/js/search.js" | fingerprint }}
-<script defer crossorigin="anonymous" src="{{ $search.RelPermalink }}" integrity="{{ $search.Data.Integrity }}"></script>
+<script defer crossorigin="anonymous" src="{{ $search.RelPermalink | absURL }}" integrity="{{ $search.Data.Integrity }}"></script>
 {{- else }}
 {{- $search := (slice $fusejs $fastsearch ) | resources.Concat "assets/js/search.js" }}
-<script defer crossorigin="anonymous" src="{{ $search.RelPermalink }}"></script>
+<script defer crossorigin="anonymous" src="{{ $search.RelPermalink | absURL }}"></script>
 {{- end }}
 {{- end -}}
 


### PR DESCRIPTION
**What does this PR change? What problem does it solve?**

When depling a Hugo website in a subdirectory of a domain instead of the root, we usually add `--baseURL` at compilation time, or add the parameter `baseURL` in config file. However, this behavior is not properly taken into account in this template for loading CSS and Javascript files, causing the stylesheet loading to fail in all pages.

Supporting the deployment in a subdirectory require to care about absolute URLs for all assets. This PR adds the `| absURL` instruction for CSS and JS loadded in `header.html`.

**Was the change discussed in an issue or in the Discussions before?**

I could not find an issue related to it, but feel free to point it out if I missed it :)

## PR Checklist

- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have verified that the code works as described/as intended.
- [ ] This change adds a Social Icon which has a permissive license to use it.
- [x] This change **does not** include any CDN resources/links.
- [x] This change **does not** include any unrelated scripts such as bash and python scripts.
- [ ] This change updates the overridden internal templates from HUGO's repository.
