### PR TITLE
:bug: Fix menu localization: site.Menus URLs are already localized

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -122,11 +122,11 @@
         {{- $currentPage := . }}
         <ul id="menu">
             {{- range site.Menus.main }}
-            {{- $menu_item_url := (cond (strings.HasSuffix .URL "/") .URL (printf "%s/" .URL) ) | absLangURL }}
-            {{- $page_url:= $currentPage.Permalink | absLangURL }}
+            {{- $menu_item_url := (cond (strings.HasSuffix .URL "/") .URL (printf "%s/" .URL) ) }}
+            {{- $page_url:= $currentPage.Permalink }}
             {{- $is_search := eq (site.GetPage .KeyName).Layout `search` }}
             <li>
-                <a href="{{ .URL | absLangURL }}" title="{{ .Title | default .Name }} {{- cond $is_search (" (Alt + /)" | safeHTMLAttr) ("" | safeHTMLAttr ) }}"
+                <a href="{{ .URL }}" title="{{ .Title | default .Name }} {{- cond $is_search (" (Alt + /)" | safeHTMLAttr) ("" | safeHTMLAttr ) }}"
                 {{- cond $is_search (" accesskey=/" | safeHTMLAttr) ("" | safeHTMLAttr ) }}>
                     <span {{- if eq $menu_item_url $page_url }} class="active" {{- end }}>
                         {{- .Pre }}


### PR DESCRIPTION
**What does this PR change? What problem does it solve?**

It appears that a website having a custom base URL generate invalid menu links using this template.
The reason is a computation of localization using `absLangURL` over `site.Menus` -> `.URL` items.

In recent versions of Hugo, the `site.Menus` items are already localized. You can see in the official example here, there is no `absLangURL` declared after `.URL`: https://gohugo.io/templates/menu/#example

`absLangURL` should be used to convert a relative URL to a localized URL in case the URL is not localized yet. Calling a already-localized URL with `absLangURL`  will append the language code twice. The problem may be not visible without declaring a custom baseURL because Hugo seems to automatically strip duplicated localization codes for ease.

**Was the change discussed in an issue or in the Discussions before?**

I have not seen any issue about that, feel free to point it out if I missed it.

## PR Checklist

- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have verified that the code works as described/as intended.
- [ ] This change adds a Social Icon which has a permissive license to use it.
- [x] This change **does not** include any CDN resources/links.
- [x] This change **does not** include any unrelated scripts such as bash and python scripts.
- [ ] This change updates the overridden internal templates from HUGO's repository.
