### PR TITLE
i18n chinese for titles and breadcrumbs of series and tags

### DIFF
--- a/i18n/zh.yaml
+++ b/i18n/zh.yaml
@@ -31,3 +31,12 @@
 
 - id: code_copied
   translation: "已复制！"
+  
+- id: articles
+  translation: "所有文章"
+
+- id: Series
+  translation: "合集"
+
+- id: Tags
+  translation: "标签"

--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -2,7 +2,7 @@
 
 {{- if .Title }}
 <header class="page-header">
-    <h1>{{ .Title }}</h1>
+    <h1>{{ i18n .Title }}</h1>
     {{- if .Description }}
     <div class="post-description">
         {{ .Description }}

--- a/layouts/partials/breadcrumbs.html
+++ b/layouts/partials/breadcrumbs.html
@@ -11,7 +11,7 @@
     {{- $bc_pg := site.GetPage ($scratch.Get "path") -}}
 
     {{- if (and ($bc_pg) (gt (len . ) 0))}}
-    {{- print "&nbsp;»&nbsp;" | safeHTML -}}<a href="{{ $bc_pg.Permalink }}">{{ $bc_pg.Name }}</a>
+    {{- print "&nbsp;»&nbsp;" | safeHTML -}}<a href="{{ $bc_pg.Permalink }}">{{ i18n $bc_pg.Name }}</a>
     {{- end }}
 
     {{- end -}}


### PR DESCRIPTION
When the default language is set to zh, the titles and breadcrumbs of /tags and /series are still in English.
So I modified i18n/zh.yaml, layouts/_default/terms.html, layouts/partials/breadcrumbs.html so that the titles and breadcrumbs of /tags and /series can be displayed in Chinese.
