### PR TITLE
Feat/improve cover image gen

### DIFF
--- a/assets/css/common/post-entry.css
+++ b/assets/css/common/post-entry.css
@@ -97,7 +97,6 @@
 
 .entry-cover img {
     border-radius: var(--radius);
-    pointer-events: none;
     width: 100%;
     height: auto;
 }

--- a/layouts/partials/cover.html
+++ b/layouts/partials/cover.html
@@ -1,8 +1,8 @@
 {{- with .cxt}} {{/* Apply proper context from dict */}}
 {{- if (and .Params.cover.image (not $.isHidden)) }}
-{{- $alt := (.Params.cover.alt | default .Params.cover.caption | plainify) }}
-{{- $loading := cond $.IsSingle "eager" "lazy" }}
 <figure class="entry-cover">
+    {{- $alt := (.Params.cover.alt | default .Params.cover.caption | plainify) }}
+    {{- $loading := cond $.IsSingle "eager" "lazy" }}
     {{- $responsiveImages := (.Params.cover.responsiveImages | default site.Params.cover.responsiveImages) | default true }}
     {{- $addLink := (and site.Params.cover.linkFullImages $.IsSingle) }}
     {{- $pageBundleCover     := (.Resources.ByType "image").GetMatch (printf "*%s*" (.Params.cover.image)) }}

--- a/layouts/partials/cover.html
+++ b/layouts/partials/cover.html
@@ -1,25 +1,27 @@
 {{- with .cxt}} {{/* Apply proper context from dict */}}
 {{- if (and .Params.cover.image (not $.isHidden)) }}
 <figure class="entry-cover">
-    {{- $alt := (.Params.cover.alt | default .Params.cover.caption | plainify) }}
     {{- $loading := cond $.IsSingle "eager" "lazy" }}
-    {{- $responsiveImages := (.Params.cover.responsiveImages | default site.Params.cover.responsiveImages) | default true }}
     {{- $addLink := (and site.Params.cover.linkFullImages $.IsSingle) }}
-    {{- $pageBundleCover     := (.Resources.ByType "image").GetMatch (printf "*%s*" (.Params.cover.image)) }}
+    {{- $prod := (hugo.IsProduction | or (eq site.Params.env "production")) }}
+    {{- $alt := (.Params.cover.alt | default .Params.cover.caption | plainify) }}
+    {{- $responsiveImages := (.Params.cover.responsiveImages | default site.Params.cover.responsiveImages) | default true }}
+
+    {{- $pageBundleCover := (.Resources.ByType "image").GetMatch (printf "*%s*" (.Params.cover.image)) }}
     {{- $globalResourcesCover := (resources.ByType "image").GetMatch (printf "*%s*" (.Params.cover.image)) }}
     {{- $cover := (or $pageBundleCover $globalResourcesCover)}}
+
+    {{- $sizes := (slice "360" "480" "720" "1080" "1500") }}
+    {{- $processableFormats := (slice "jpg" "jpeg" "png" "tif" "bmp" "gif") -}}
+    {{- if hugo.IsExtended -}}
+        {{- $processableFormats = $processableFormats | append "webp" -}}
+    {{- end -}}
 
     {{- if $addLink }}
         <a href="{{ (path.Join .RelPermalink .Params.cover.image) | absURL }}" target="_blank" rel="noopener noreferrer">
     {{- end }}
 
     {{- if $cover -}}{{/* i.e it is present in page bundle */}}
-        {{- $sizes := (slice "360" "480" "720" "1080" "1500") }}
-        {{- $processableFormats := (slice "jpg" "jpeg" "png" "tif" "bmp" "gif") -}}
-        {{- if hugo.IsExtended -}}
-            {{- $processableFormats = $processableFormats | append "webp" -}}
-        {{- end -}}
-        {{- $prod := (hugo.IsProduction | or (eq site.Params.env "production")) }}
         {{- if (and (in $processableFormats $cover.MediaType.SubType) ($responsiveImages) (eq $prod true)) }}
         <img loading="{{$loading}}" srcset="{{- range $size := $sizes -}}
                         {{- if (ge $cover.Width $size) -}}

--- a/layouts/partials/cover.html
+++ b/layouts/partials/cover.html
@@ -17,26 +17,29 @@
         {{- $processableFormats = $processableFormats | append "webp" -}}
     {{- end -}}
 
+    {{- $imgdl := (.Params.cover.image) | absURL }}
+    {{- if $cover -}}
+        {{- $imgdl = $cover.Permalink }}
+    {{- end -}}
+
     {{- if $addLink }}
-        <a href="{{ (path.Join .RelPermalink .Params.cover.image) | absURL }}" target="_blank" rel="noopener noreferrer">
+        <a href="{{ $imgdl }}" target="_blank" rel="noopener noreferrer">
     {{- end }}
 
     {{- if $cover -}}{{/* i.e it is present in page bundle */}}
         {{- if (and (in $processableFormats $cover.MediaType.SubType) ($responsiveImages) (eq $prod true)) }}
-        <img loading="{{$loading}}" srcset="{{- range $size := $sizes -}}
-                        {{- if (ge $cover.Width $size) -}}
-                        {{ printf "%s %s" (($cover.Resize (printf "%sx" $size)).Permalink) (printf "%sw ," $size) -}}
-                        {{ end }}
-                    {{- end -}}{{$cover.Permalink }} {{printf "%dw" ($cover.Width)}}" 
-            sizes="(min-width: 768px) 720px, 100vw" src="{{ $cover.Permalink }}" alt="{{ $alt }}" 
-            width="{{ $cover.Width }}" height="{{ $cover.Height }}">
+            <img loading="{{$loading}}" srcset="{{- range $size := $sizes -}}
+                            {{- if (ge $cover.Width $size) -}}
+                            {{ printf "%s %s" (($cover.Resize (printf "%sx" $size)).Permalink) (printf "%sw ," $size) -}}
+                            {{ end }}
+                        {{- end -}}{{$cover.Permalink }} {{printf "%dw" ($cover.Width)}}" 
+                sizes="(min-width: 768px) 720px, 100vw" src="{{ $cover.Permalink }}" 
+                width="{{ $cover.Width }}" height="{{ $cover.Height }}" alt="{{ $alt }}">
         {{- else }}{{/* Unprocessable image or responsive images disabled */}}
-        <img loading="{{$loading}}" src="{{ (path.Join .RelPermalink .Params.cover.image) | absURL }}" alt="{{ $alt }}">
+        <img loading="{{ $loading }}" src="{{ $imgdl }}" alt="{{ $alt }}">
         {{- end }}
     {{- else }}{{/* For absolute urls and external links, no img processing here */}}
-        {{- if $addLink }}<a href="{{ (.Params.cover.image) | absURL }}" target="_blank"
-            rel="noopener noreferrer">{{ end -}}
-            <img loading="{{$loading}}" src="{{ (.Params.cover.image) | absURL }}" alt="{{ $alt }}">
+        <img loading="{{ $loading }}" src="{{ $imgdl }}" alt="{{ $alt }}">
     {{- end }}
 
     {{- if $addLink }}

--- a/layouts/partials/cover.html
+++ b/layouts/partials/cover.html
@@ -28,15 +28,19 @@
 
     {{- if $cover -}}{{/* i.e it is present in page bundle */}}
         {{- if (and (in $processableFormats $cover.MediaType.SubType) ($responsiveImages) (eq $prod true)) }}
-            <img loading="{{$loading}}" srcset="{{- range $size := $sizes -}}
-                            {{- if (ge $cover.Width $size) -}}
-                            {{ printf "%s %s" (($cover.Resize (printf "%sx" $size)).Permalink) (printf "%sw ," $size) -}}
-                            {{ end }}
-                        {{- end -}}{{$cover.Permalink }} {{printf "%dw" ($cover.Width)}}" 
-                sizes="(min-width: 768px) 720px, 100vw" src="{{ $cover.Permalink }}" 
-                width="{{ $cover.Width }}" height="{{ $cover.Height }}" alt="{{ $alt }}">
+            <img loading="{{$loading}}"
+                srcset='{{- range $size := $sizes -}}
+                            {{- if (ge $cover.Width $size) }}
+                                {{- printf "%s %s" (($cover.Resize (printf "%sx" $size)).Permalink) (printf "%sw," $size) }}
+                            {{- end }}
+                        {{- end }}
+                        {{- printf "%s %dw" ($cover.Permalink) ($cover.Width) }}'
+                src="{{ $cover.Permalink }}"
+                sizes="(min-width: 768px) 720px, 100vw"
+                width="{{ $cover.Width }}" height="{{ $cover.Height }}"
+                alt="{{ $alt }}">
         {{- else }}{{/* Unprocessable image or responsive images disabled */}}
-        <img loading="{{ $loading }}" src="{{ $imgdl }}" alt="{{ $alt }}">
+            <img loading="{{ $loading }}" src="{{ $imgdl }}" alt="{{ $alt }}">
         {{- end }}
     {{- else }}{{/* For absolute urls and external links, no img processing here */}}
         <img loading="{{ $loading }}" src="{{ $imgdl }}" alt="{{ $alt }}">

--- a/layouts/partials/cover.html
+++ b/layouts/partials/cover.html
@@ -8,9 +8,12 @@
     {{- $pageBundleCover     := (.Resources.ByType "image").GetMatch (printf "*%s*" (.Params.cover.image)) }}
     {{- $globalResourcesCover := (resources.ByType "image").GetMatch (printf "*%s*" (.Params.cover.image)) }}
     {{- $cover := (or $pageBundleCover $globalResourcesCover)}}
+
+    {{- if $addLink }}
+        <a href="{{ (path.Join .RelPermalink .Params.cover.image) | absURL }}" target="_blank" rel="noopener noreferrer">
+    {{- end }}
+
     {{- if $cover -}}{{/* i.e it is present in page bundle */}}
-        {{- if $addLink }}<a href="{{ (path.Join .RelPermalink .Params.cover.image) | absURL }}" target="_blank"
-            rel="noopener noreferrer">{{ end -}}
         {{- $sizes := (slice "360" "480" "720" "1080" "1500") }}
         {{- $processableFormats := (slice "jpg" "jpeg" "png" "tif" "bmp" "gif") -}}
         {{- if hugo.IsExtended -}}
@@ -33,10 +36,16 @@
             rel="noopener noreferrer">{{ end -}}
             <img loading="{{$loading}}" src="{{ (.Params.cover.image) | absURL }}" alt="{{ $alt }}">
     {{- end }}
-    {{- if $addLink }}</a>{{ end -}}
+
+    {{- if $addLink }}
+        </a>
+    {{ end -}}
+
     {{/*  Display Caption  */}}
     {{- if $.IsSingle }}
-        {{ with .Params.cover.caption }}<p>{{ . | markdownify }}</p>{{- end }}
+        {{- with .Params.cover.caption }}
+            <p>{{ . | markdownify }}</p>
+        {{- end }}
     {{- end }}
 </figure>
 {{- end }}{{/* End image */}}

--- a/layouts/partials/cover.html
+++ b/layouts/partials/cover.html
@@ -10,8 +10,8 @@
     {{- $pageBundleCover := (.Resources.ByType "image").GetMatch (printf "*%s*" (.Params.cover.image)) }}
     {{- $globalResourcesCover := (resources.ByType "image").GetMatch (printf "*%s*" (.Params.cover.image)) }}
     {{- $cover := (or $pageBundleCover $globalResourcesCover)}}
-    {{/* We are not using the .Param.cover.relative to decide the location of image */}}
-    {{/* If we have the image in pageBundle or globalResources we can process the image */}}
+    {{- /* We are not using the .Param.cover.relative to decide the location of image */}}
+    {{- /* If we have the image in pageBundle or globalResources we can process the image */}}
 
     {{- $sizes := (slice "360" "480" "720" "1080" "1500") }}
     {{- $processableFormats := (slice "jpg" "jpeg" "png" "tif" "bmp" "gif") -}}
@@ -46,17 +46,17 @@
             <img loading="{{ $loading }}" src="{{ $imgdl }}" alt="{{ $alt }}">
         {{- end }}
     {{- else }}
-        {{/* For absolute urls and external links, no img processing here */}}
+        {{- /* For absolute urls and external links, no img processing here */}}
         <img loading="{{ $loading }}" src="{{ $imgdl }}" alt="{{ $alt }}">
     {{- end }}
 
     {{- if $addLink }}
         </a>
-    {{ end -}}
+    {{- end -}}
 
-    {{/*  Display Caption  */}}
+    {{- /*  Display Caption  */}}
     {{- if $.IsSingle }}
-        {{- with .Params.cover.caption }}
+        {{ with .Params.cover.caption -}}
             <figcaption>{{ . | markdownify }}</figcaption>
         {{- end }}
     {{- end }}

--- a/layouts/partials/cover.html
+++ b/layouts/partials/cover.html
@@ -57,7 +57,7 @@
     {{/*  Display Caption  */}}
     {{- if $.IsSingle }}
         {{- with .Params.cover.caption }}
-            <p>{{ . | markdownify }}</p>
+            <figcaption>{{ . | markdownify }}</figcaption>
         {{- end }}
     {{- end }}
 </figure>

--- a/layouts/partials/cover.html
+++ b/layouts/partials/cover.html
@@ -10,6 +10,8 @@
     {{- $pageBundleCover := (.Resources.ByType "image").GetMatch (printf "*%s*" (.Params.cover.image)) }}
     {{- $globalResourcesCover := (resources.ByType "image").GetMatch (printf "*%s*" (.Params.cover.image)) }}
     {{- $cover := (or $pageBundleCover $globalResourcesCover)}}
+    {{/* We are not using the .Param.cover.relative to decide the location of image */}}
+    {{/* If we have the image in pageBundle or globalResources we can process the image */}}
 
     {{- $sizes := (slice "360" "480" "720" "1080" "1500") }}
     {{- $processableFormats := (slice "jpg" "jpeg" "png" "tif" "bmp" "gif") -}}
@@ -26,7 +28,8 @@
         <a href="{{ $imgdl }}" target="_blank" rel="noopener noreferrer">
     {{- end }}
 
-    {{- if $cover -}}{{/* i.e it is present in page bundle */}}
+    {{- if $cover -}}
+        {{/* i.e it is present in page bundle */}}
         {{- if (and (in $processableFormats $cover.MediaType.SubType) ($responsiveImages) (eq $prod true)) }}
             <img loading="{{$loading}}"
                 srcset='{{- range $size := $sizes -}}
@@ -42,7 +45,8 @@
         {{- else }}{{/* Unprocessable image or responsive images disabled */}}
             <img loading="{{ $loading }}" src="{{ $imgdl }}" alt="{{ $alt }}">
         {{- end }}
-    {{- else }}{{/* For absolute urls and external links, no img processing here */}}
+    {{- else }}
+        {{/* For absolute urls and external links, no img processing here */}}
         <img loading="{{ $loading }}" src="{{ $imgdl }}" alt="{{ $alt }}">
     {{- end }}
 


### PR DESCRIPTION
<!--

## READ BEFORE OPENING A PR

Thank you for contributing to hugo-PaperMod!
Please fill out the following questions to make it easier for us to review your
changes. You do not need to check all the boxes below.

**NOTE**: PaperMod does not have any external dependencies fetched from 3rd party
CDN servers. However we do have custom Head/Footer extender templates which you can use
to add those to your website.
https://github.com/adityatelange/hugo-PaperMod/wiki/FAQs#custom-head--footer

-->


**What does this PR change? What problem does it solve?**

This pull request introduces improvements to the cover image generation in the Hugo PaperMod theme. The changes include:

- Refactoring: cover.html has been refactored to use the <figcaption> element for image captions, enhancing HTML5 semantics and accessibility.
- Bug Fixes: Removed pointer-event prevention from entry-cover images to ensure better user interaction.
- Code Quality: Added comments and managed whitespace for better code readability.


**Was the change discussed in an issue or in the Discussions before?**

No.

## PR Checklist

- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [ ] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have verified that the code works as described/as intended.
- [ ] This change adds a Social Icon which has a permissive license to use it.
- [x] This change **does not** include any CDN resources/links.
- [x] This change **does not** include any unrelated scripts such as bash and python scripts.
- [ ] This change updates the overridden internal templates from HUGO's repository.
