### PR TITLE
Markdownify author.html partial

### DIFF
--- a/layouts/partials/author.html
+++ b/layouts/partials/author.html
@@ -2,8 +2,8 @@
 {{- $author := (.Params.author | default site.Params.author) }}
 {{- $author_type := (printf "%T" $author) }}
 {{- if (or (eq $author_type "[]string") (eq $author_type "[]interface {}")) }}
-{{- (delimit $author ", " ) }}
+{{- (delimit $author ", " ) | markdownify }}
 {{- else }}
-{{- $author }}
+{{- $author | markdownify }}
 {{- end }}
 {{- end -}}


### PR DESCRIPTION
<!--

## READ BEFORE OPENING A PR

Thank you for contributing to hugo-PaperMod!
Please fill out the following questions to make it easier for us to review your
changes. You do not need to check all the boxes below.

**NOTE**: PaperMod does not have any external dependencies fetched from 3rd party
CDN servers. However we do have custom Head/Footer extender templates which you can use
to add those to your website.
https://github.com/adityatelange/hugo-PaperMod/wiki/FAQs#custom-head--footer

-->


**What does this PR change? What problem does it solve?**

Markdownify the author string so that we can use email, github, or site section links for authors more easily.


**Was the change discussed in an issue or in the Discussions before?**

I did approximately 1 second of searching and didn't see this, but this is a standard feature in other hugo themes so I thought I'd suggest it here

## PR Checklist

- [] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have verified that the code works as described/as intended.
- [ ] This change **does not** include any CDN resources/links.
- [ ] This change **does not** include any unrelated scripts such as bash and python scripts.
