### PR TITLE
Add ability to add meta tag for fediverse author attribution

### DIFF
--- a/layouts/partials/templates/opengraph.html
+++ b/layouts/partials/templates/opengraph.html
@@ -78,5 +78,8 @@
         <meta property="fb:admins" content="{{ . }}">
       {{- end }}
     {{- end }}
+    {{- with .fediverse_creator }}
+        <meta name="fediverse:creator" content="{{ . }}">
+    {{- end }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
**What does this PR change? What problem does it solve?**

Mastodon (and potentially other fediverse clients) can attribute a shared link to a fediverse user.

This adds the ability to do so by setting the `social.fediverse_creator` to "@user@instance.example.com".

It has the prerequisite that the website the shared link is from is on your allow list. To set this up in Mastodon:
1. "Preferences" on the right-hand side
2. "Public profile" on the left-hand side
3. "Versification" tab in the top bar
4. In the section "Author attribution", add all relevant domains to the field for "Websites allowed to credit you" (one per line)
5. "Save changes"

Note that this is not retroactive and failing to set up to the correct domain in the allow list beforehand will not update old links in post and might even be cached for a specific link on a specific instance.

Furthermore, the docs for this feature should include the prerequisite and its pitfall of not setting up the allowed domain beforehand.

Also, this might also be interesting to do on an article basis. It is not for me right now.


## PR Checklist

- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have verified that the code works as described/as intended.
- [ ] This change adds a Social Icon which has a permissive license to use it.
- [x] This change **does not** include any CDN resources/links.
- [x] This change **does not** include any unrelated scripts such as bash and python scripts.
- [x] This change updates the overridden internal templates from HUGO's repository.
