### PR TITLE
fix: comma inclusion in breadcrumb schema

### DIFF
--- a/layouts/partials/templates/schema_json.html
+++ b/layouts/partials/templates/schema_json.html
@@ -49,10 +49,10 @@
 
   {{- end }}
   {{- /*  self-page addition  */ -}}
-  {{- if (ge (len $bc_list) 2) }}, {{end }}
+  {{- if $bc_list }}, {{end}}
     {
       "@type": "ListItem",
-      "position": {{len $bc_list}},
+      "position": {{ add (len $bc_list) 1 }},
       "name": {{ .Name }},
       "item": {{ .Permalink | safeHTML }}
     }


### PR DESCRIPTION
**What does this PR change? What problem does it solve?**
This PR fixes a JSON syntax error in the schema_json.html template that causes Hugo builds to fail. The error occurs in the breadcrumb list generation where commas between JSON objects are not properly handled when adding the self-page item to the breadcrumb list.

The current template attempts to add a comma before the self-page item using this condition:
```html
{{- if (ge (len $bc_list) 2) }}, {{end }}
```

This causes build failures with error messages like:
```
ERROR failed to process "/posts/example/index.html": "/var/folders/hugo-transform-error:99:40": expected comma character or an array or object ending on line 99 and column 40"
Error: error building site: render: failed to render pages: failed to process "/authors/luke-skywalker/index.html": "/var/folders/hugo-transform-error:87:40": expected comma character or an array or object ending on line 87 and column 40
```

The fix simplifies the comma handling logic to:
```html
{{- if $bc_list }}, {{end}}
```

This ensures proper JSON syntax by adding a comma whenever there are existing breadcrumb items before the self-page addition.

**Was the change discussed in an issue or in the Discussions before?**
No prior discussion. The issue was discovered when building a site with the theme and verified through testing.

## PR Checklist
- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [x] I have enabled maintainer edits for this PR.
- [x] I have verified that the code works as described/as intended.
- [ ] This change adds a Social Icon which has a permissive license to use it.
- [x] This change **does not** include any CDN resources/links.
- [x] This change **does not** include any unrelated scripts such as bash and python scripts.
- [x] This change updates the overridden internal templates from HUGO's repository.