### PR TITLE
fix: unexpected shift of the entire article when anchor hidden = false

### DIFF
--- a/assets/css/common/post-single.css
+++ b/assets/css/common/post-single.css
@@ -69,11 +69,15 @@
     font-size: 12px;
 }
 
-.post-content a,
-.toc a:hover {
-    box-shadow: 0 1px 0;
-    box-decoration-break: clone;
-    -webkit-box-decoration-break: clone;
+
+.post-content h1,
+.post-content h2,
+.post-content h3,
+.post-content h4,
+.post-content h5,
+.post-content h6 {
+    position: relative;
+    display: inline-block;
 }
 
 .post-content a code {
@@ -356,11 +360,38 @@ h3:hover .anchor,
 h4:hover .anchor,
 h5:hover .anchor,
 h6:hover .anchor {
+    position: absolute;
     display: inline-flex;
     color: var(--secondary);
     margin-inline-start: 8px;
     font-weight: 500;
     user-select: none;
+    padding-left: 30px;
+    margin-left: -25px;
+}
+
+h1:hover .anchor::after,
+h2:hover .anchor::after,
+h3:hover .anchor::after {
+    content: '';
+    position: absolute;
+    bottom: 0;
+    left: 25px;
+    width: 50%;
+    height: 1px;
+    background-color: var(--secondary);
+}
+
+h4:hover .anchor::after,
+h5:hover .anchor::after,
+h6:hover .anchor::after {
+    content: '';
+    position: absolute;
+    bottom: 0;
+    left: 29px;
+    width: 25%;
+    height: 1px;
+    background-color: var(--secondary);
 }
 
 .paginav {


### PR DESCRIPTION
**What does this PR change? What problem does it solve?**

When a heading occupies an entire line, moving the mouse over the heading causes the entire article to unexpectedly shift down by one line.
And adjusted the anchor's underline to align with this modification.

Before:
![before](https://github.com/user-attachments/assets/8cb86660-4894-42a2-8357-c11f518febcc)

After the fix, the following effects are achieved:
![after](https://github.com/user-attachments/assets/5ff7992c-c1b3-4bfa-8776-351d8bd4f7b4)

h1, h2, h3, h4, h5, and h6 all function correctly.

## PR Checklist

- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have verified that the code works as described/as intended.
- [ ] This change adds a Social Icon which has a permissive license to use it.
- [x] This change **does not** include any CDN resources/links.
- [x] This change **does not** include any unrelated scripts such as bash and python scripts.
- [ ] This change updates the overridden internal templates from HUGO's repository.