### PR TITLE
Fix #1624. Search for the image in the page resources.

### DIFF
--- a/layouts/shortcodes/figure.html
+++ b/layouts/shortcodes/figure.html
@@ -5,7 +5,14 @@
     {{- if .Get "link" -}}
         <a href="{{ .Get "link" }}"{{ with .Get "target" }} target="{{ . }}"{{ end }}{{ with .Get "rel" }} rel="{{ . }}"{{ end }}>
     {{- end }}
-    <img loading="lazy" src="{{ .Get "src" }}{{- if eq (.Get "align") "center" }}#center{{- end }}"
+    {{- $u := urls.Parse (.Get "src") -}}
+    {{- $src := $u.String -}}
+    {{- if not $u.IsAbs -}}
+        {{- with or (.Page.Resources.Get $u.Path) (resources.Get $u.Path) -}}
+            {{- $src = .RelPermalink -}}
+        {{- end -}}
+    {{- end -}}
+    <img loading="lazy" src="{{ $src }}{{- if eq (.Get "align") "center" }}#center{{- end }}"
          {{- if or (.Get "alt") (.Get "caption") }}
          alt="{{ with .Get "alt" }}{{ . }}{{ else }}{{ .Get "caption" | markdownify| plainify }}{{ end }}"
          {{- end -}}


### PR DESCRIPTION
Fixes image URL for multilingual sites when the image resource is only defined for the default language.

**What does this PR change? What problem does it solve?**

PaperMod defines a custom `figure` shortcode which currently fails to provide a valid link in a multilingual site. As stated in [Hugo docs](https://gohugo.io/content-management/multilingual/#page-bundles), we should be able to use image resources from any page bundle.

The old shortcode uses the img src as is without searching for the resource in other page bundles. See the linked issue for an example.

**Was the change discussed in an issue or in the Discussions before?**

Closes #1624 

## PR Checklist

- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have verified that the code works as described/as intended.
- [ ] This change adds a Social Icon which has a permissive license to use it.
- [x] This change **does not** include any CDN resources/links.
- [x] This change **does not** include any unrelated scripts such as bash and python scripts.
- [ ] This change updates the overridden internal templates from HUGO's repository.
