### PR TITLE
Fix accessibility of theme toggle button 

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -74,7 +74,7 @@
             {{- end }}
             <div class="logo-switches">
                 {{- if (not site.Params.disableThemeToggle) }}
-                <button id="theme-toggle" accesskey="t" title="(Alt + T)">
+                <button id="theme-toggle" accesskey="t" title="(Alt + T)" aria-label="Toggle theme">
                     <svg id="moon" xmlns="http://www.w3.org/2000/svg" width="24" height="18" viewBox="0 0 24 24"
                         fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
                         stroke-linejoin="round">


### PR DESCRIPTION
**What does this PR change? What problem does it solve?**

- The button to change the theme has title `Alt + T`
-  this gives it a good tooltip on hover but it a screen reader user would just hear `Alt + T` and not know what the button does. 
    - this is important to add since it is on the front page of every papermod site 
- Adding `aria-label="Toggle theme"` makes the screen reader speak out `Toggle theme` which is the semantic purpose of the button without overriding the title or tooltip 

This isn't perfect and the button could have a white rectangle around it as well for focus but wanted to just add this since it doesn't require me going into the CSS as a first PR

**Was the change discussed in an issue or in the Discussions before?**

Not that I am aware. 

## PR Checklist


- [x ] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ x] I have verified that the code works as described/as intended.
- [x ] This change **does not** include any CDN resources/links.
- [x ] This change **does not** include any unrelated scripts such as bash and python scripts.
