### PR TITLE
Add ability to open menu items in a new tab

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -126,7 +126,7 @@
             {{- $page_url:= $currentPage.Permalink | absLangURL }}
             {{- $is_search := eq (site.GetPage .KeyName).Layout `search` }}
             <li>
-                <a href="{{ .URL | absLangURL }}" title="{{ .Title | default .Name }} {{- cond $is_search (" (Alt + /)" | safeHTMLAttr) ("" | safeHTMLAttr ) }}"
+                <a href="{{ .URL | absLangURL }}" {{- if (hasPrefix .Identifier "ext-") }} target="_blank" {{- end }} title="{{ .Title | default .Name }} {{- cond $is_search (" (Alt + /)" | safeHTMLAttr) ("" | safeHTMLAttr ) }}"
                 {{- cond $is_search (" accesskey=/" | safeHTMLAttr) ("" | safeHTMLAttr ) }}>
                     <span {{- if eq $menu_item_url $page_url }} class="active" {{- end }}>
                         {{- .Pre }}


### PR DESCRIPTION
**What does this PR change? What problem does it solve?**

Add the ability to open specific menu items in a new tab. When an identifier begins with "ext-", it will add a `target="_blank"`.  This is independent of whether the link is an external link, so the user can decide themselves. For example, if I want to make my blog page open in a new tab:

```yaml
menu:
  main:
    - identifier: "ext-blog"
      name: Blog
      url: /blog/
      # or url: https://blogsite.com 
      weight: 1
```

**Was the change discussed in an issue or in the Discussions before?**

Inspired by this [PR](https://github.com/JupiterBroadcasting/jupiterbroadcasting.com/issues/47)

This [discussion](https://github.com/adityatelange/hugo-PaperMod/discussions/760) to open all external links in a new tab.
Hugo still has not implemented target parameter for menu items. [Issue](https://github.com/gohugoio/hugo/issues/3600)

## PR Checklist

- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have verified that the code works as described/as intended.
- [ ] This change adds a Social Icon which has a permissive license to use it.
- [x] This change **does not** include any CDN resources/links.
- [x] This change **does not** include any unrelated scripts such as bash and python scripts.
- [ ] This change updates the overridden internal templates from HUGO's repository.
