### PR TITLE
Fix image dimension condition checks

### DIFF
--- a/layouts/partials/index_profile.html
+++ b/layouts/partials/index_profile.html
@@ -13,7 +13,7 @@
             {{- end -}}
             {{- $prod := (hugo.IsProduction | or (eq site.Params.env "production")) }}
             {{- if and (in $processableFormats $img.MediaType.SubType) (eq $prod true)}}
-                {{- if (not (and (not .imageHeight) (not .imageWidth))) }}
+                {{- if and .imageWidth .imageHeight }}
                     {{- $img = $img.Resize (printf "%dx%d" .imageWidth .imageHeight) }}
                 {{- else if .imageHeight }}
                     {{- $img = $img.Resize (printf "x%d" .imageHeight) }}


### PR DESCRIPTION
Update index_profile.html

<!--

## READ BEFORE OPENING A PR

Thank you for contributing to hugo-PaperMod!
Please fill out the following questions to make it easier for us to review your
changes. You do not need to check all the boxes below.

**NOTE**: PaperMod does not have any external dependencies fetched from 3rd party
CDN servers. However we do have custom Head/Footer extender templates which you can use
to add those to your website.
https://github.com/adityatelange/hugo-PaperMod/wiki/FAQs#custom-head--footer

-->


**What does this PR change? What problem does it solve?**

<!--
Describe the changes and their purpose here, as detailed as and if needed.

Please do not add 2 unrelated changes in a single PR as it is difficult to track/revert those in future.
-->

1. Fixes incorrect dimension check condition that caused `Resize` method to receive invalid parameters when only one dimension was specified
2. Optimizes conditional judgment sequence to properly handle scenarios:
   - When only width is provided
   - When only height is provided

**Was the change discussed in an issue or in the Discussions before?**

<!--
Link issues and relevant Discussions posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

No existing discussion found.

## PR Checklist

- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have verified that the code works as described/as intended.
- [ ] This change adds a Social Icon which has a permissive license to use it.
- [x] This change **does not** include any CDN resources/links.
- [x] This change **does not** include any unrelated scripts such as bash and python scripts.
- [x] This change updates the overridden internal templates from HUGO's repository.
