### PR TITLE
Declare content as a safeHTML string.

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -37,8 +37,8 @@
   {{- if .Content }}
   <div class="post-content">
     {{- if not (.Param "disableAnchoredHeadings") }}
-    {{- partial "anchored_headings.html" .Content -}}
-    {{- else }}{{ .Content }}{{ end }}
+    {{- partial "anchored_headings.html" .Content | safe.HTML -}}
+    {{- else }}{{ .Content | safe.HTML }}{{ end }}
   </div>
   {{- end }}
 


### PR DESCRIPTION
**What does this PR change? What problem does it solve?**

As a content creator I am currently struggling to add custom html tags to my content, hindering me to use e.g. linebreak elements `<br />` in my texts.

[Declaring content as a safeHTML string](https://gohugo.io/functions/safe/html/) allows PaperMod users to turn on and leverage unsafe rendering mode of goldmark:

```
markup:
  goldmark:
    renderer:
      unsafe: true
```

**Was the change discussed in an issue or in the Discussions before?**

Not that I am aware of.

## PR Checklist

- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have verified that the code works as described/as intended.
- [ ] This change adds a Social Icon which has a permissive license to use it.
- [x] This change **does not** include any CDN resources/links.
- [x] This change **does not** include any unrelated scripts such as bash and python scripts.
- [ ] This change updates the overridden internal templates from HUGO's repository.
