### PR TITLE
fix: correct partials path in layouts/partials/templates directory

### DIFF
--- a/layouts/partials/templates/schema_json.html
+++ b/layouts/partials/templates/schema_json.html
@@ -85,7 +85,7 @@
     {{ (path.Join .RelPermalink .Params.cover.image ) | absURL }},
     {{- end}}
   {{- else }}
-    {{- $images := partial "partials/templates/_funcs/get-page-images" . -}}
+    {{- $images := partial "templates/_funcs/get-page-images" . -}}
     {{- with index $images 0 -}}
   "image": {{ .Permalink }},
     {{- end }}

--- a/layouts/partials/templates/twitter_cards.html
+++ b/layouts/partials/templates/twitter_cards.html
@@ -6,7 +6,7 @@
 <meta name="twitter:image" content="{{ (path.Join .RelPermalink .Params.cover.image ) | absURL }}">
 {{- end}}
 {{- else }}
-{{- $images := partial "partials/templates/_funcs/get-page-images" . -}}
+{{- $images := partial "templates/_funcs/get-page-images" . -}}
 {{- with index $images 0 -}}
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:image" content="{{ .Permalink }}">


### PR DESCRIPTION
**What does this PR change? What problem does it solve?**
When I upgraded my Hugo site to the latest version of Hugo I got this error that stopped me from running my Hugo server.

```
WARN  Partial name "partials/templates/_funcs/get-page-images" starting with 'partials/' (as in {{ partial "partials/templates/_funcs/get-page-images"}}) is most likely not what you want. Before 0.146.0 we did a double lookup in this situation.
You can suppress this warning by adding the following to your site configuration:
ignoreLogs = ['warning-partial-superfluous-prefix']
ERROR render of "/categories/python" failed: ".../themes/PaperMod/layouts/_default/baseof.html:9:8": execute of template failed: template: list.html:9:8: executing "list.html" at <partial "head.html" .>: error calling partial: ".../themes/PaperMod/layouts/partials/head.html:9:15": execute of template failed: template: _partials/templates/twitter_cards.html:9:15: executing "partials/templates/twitter_cards.html" at <partial "partials/templates/_funcs/get-page-images" .>: error calling partial: partial "partials/templates/_funcs/get-page-images" not found
...
```

TLDR: Hugo changed it path resolution system by eliminating the double lookup, breaking references such as `partial "partials/..."`. This prevented me from running `hugo server -D`

**Describe the changes and their purpose here, as detailed as and if needed.**
Remove `partials` in partial paths to follow Hugo's updated guidelines on path resolution.


**Was the change discussed in an issue or in the Discussions before?**
No but it's a 2 line change :)


## PR Checklist

- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have verified that the code works as described/as intended.
