### PR TITLE
fix/googleanalytics: add dynamic Google Analytics partial using params

### DIFF
--- a/layouts/partials/google_analytics.html
+++ b/layouts/partials/google_analytics.html
@@ -1,0 +1,10 @@
+{{- $gaID := .Site.Params.services.googleAnalytics.id }}
+{{- if and (eq .Site.Params.env "production") $gaID }}
+<script async src="https://www.googletagmanager.com/gtag/js?id={{ $gaID }}"></script>
+<script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag() { dataLayer.push(arguments); }
+    gtag('js', new Date());
+    gtag('config', '{{ $gaID }}');
+</script>
+{{- end }}


### PR DESCRIPTION
Fix: add dynamic Google Analytics partial using params

- Added layouts/partials/google_analytics.html
- Fetch Google Analytics ID from `.Site.Params.services.googleAnalytics.id`
- Load GA script only if environment is 'production' and ID is present
- Updated examplesite/config.yml with sample Google Analytics config (in another PR to examplesite branch)
- Ensures compatibility with Hugo 0.111+ where `.Site.GoogleAnalytics` and `.Site.Services` are deprecated
