### PR TITLE
fix-exmpleSite/googleanalytics: add Google Analytics config example under examplesite

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -182,6 +182,11 @@ params:
   # icon: icon.png
   # iconHeight: 35
 
+  # Added layouts/partials/google_analytics.html in PR https://github.com/adityatelange/hugo-PaperMod/pull/1734
+  services:
+    googleAnalytics:
+      id: G-XXXXXXXXXX
+
   # analytics:
   #     google:
   #         SiteVerificationTag: "XYZabc"


### PR DESCRIPTION
docs: add example Google Analytics config in examplesite

- Adds sample Google Analytics configuration under `params.services.googleAnalytics.id`
- Helps demonstrate usage of the new dynamic GA partial
- Continuation of master PR: https://github.com/adityatelange/hugo-PaperMod/pull/1734
