### PR TITLE
Add rel=edit attribute to change suggestion link 

### DIFF
--- a/layouts/partials/edit_post.html
+++ b/layouts/partials/edit_post.html
@@ -2,7 +2,7 @@
 {{- $fileUrlPath := path.Join .File.Path }}
 
 {{- if or .Params.author site.Params.author (.Param "ShowReadingTime") (not .Date.IsZero) .IsTranslated }}&nbsp;|&nbsp;{{- end -}}
-<a href="{{ .Params.editPost.URL | default site.Params.editPost.URL }}{{ if .Params.editPost.appendFilePath | default ( site.Params.editPost.appendFilePath | default false ) }}/{{ $fileUrlPath }}{{ end }}" rel="noopener noreferrer" target="_blank">
+<a href="{{ .Params.editPost.URL | default site.Params.editPost.URL }}{{ if .Params.editPost.appendFilePath | default ( site.Params.editPost.appendFilePath | default false ) }}/{{ $fileUrlPath }}{{ end }}" rel="noopener noreferrer edit" target="_blank">
     {{- .Params.editPost.Text | default (site.Params.editPost.Text | default (i18n "edit_post" | default "Edit")) -}}
 </a>
 {{- end }}


### PR DESCRIPTION
**What does this PR change? What problem does it solve?**

This PR adds the `rel="edit"` attribute to the Hugo edit link.

`rel=edit` lets a page indicate that the linked resource can be used to edit the page. It is defined at https://microformats.org/wiki/rel-edit. This can then be parsed by tools like the Universal Edit Button and custom bookmarklets to open the edit page corresponding with a website. 

**Was the change discussed in an issue or in the Discussions before?**

No.

## PR Checklist

- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [X] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [X] I have verified that the code works as described/as intended.
- [ ] This change adds a Social Icon which has a permissive license to use it.
- [X] This change **does not** include any CDN resources/links.
- [X] This change **does not** include any unrelated scripts such as bash and python scripts.
- [ ] This change updates the overridden internal templates from HUGO's repository.
