### PR TITLE
[Enhancement] Support for footer menu

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -19,6 +19,16 @@
         <a href="https://gohugo.io/" rel="noopener noreferrer" target="_blank">Hugo</a> &
         <a href="https://github.com/adityatelange/hugo-PaperMod/" rel="noopener" target="_blank">PaperMod</a>
     </span>
+
+    {{- with .Site.Menus.footer }}
+        <nav class="footer-menu">
+            {{- $last := sub (len .) 1 }}
+            {{- range $i, $e := . }}
+                <a href="{{ $e.URL | relLangURL }}">{{ $e.Name }}</a>
+                {{- if lt $i $last }} · {{- end }}
+            {{- end }}
+        </nav>
+    {{- end }}
 </footer>
 {{- end }}
 


### PR DESCRIPTION
**What does this PR change? What problem does it solve?**
This PR adds support of the footer menus, that are described in Hugo's documentation [here](https://gohugo.io/content-management/menus/#define-in-front-matter). When rendered it looks something like in this example as seen on this screenshot:
![image](https://github.com/user-attachments/assets/f968483a-68e6-4ad0-9639-373043cfcebf)

Links are separated by `" · "`. This does not get printed after the last footer link of course to only have this separator between links and not after links.

In my case, working with a toml config, I had this menu defined as:
```toml
[[menu.footer]]
name = "Imprint"
url = "/imprint"
weight = 10

[[menu.footer]]
name = "Privacy Policy"
url = "/privacy-policy"
weight = 20
```


**Was the change discussed in an issue or in the Discussions before?**
Not that I am aware off. I just saw https://github.com/adityatelange/hugo-PaperMod/issues/1481, but this behaves differently from my PR as far as I understand.

## PR Checklist

- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have verified that the code works as described/as intended.
- [ ] This change adds a Social Icon which has a permissive license to use it.
- [x] This change **does not** include any CDN resources/links.
- [x] This change **does not** include any unrelated scripts such as bash and python scripts.
- [ ] This change updates the overridden internal templates from HUGO's repository.
