### PR TITLE
Fix for hugo v0.147.6 change of Pagination

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -45,7 +45,7 @@
 {{- $pages = where $pages "Params.hiddenInHomeList" "!=" "true"  }}
 {{- end }}
 
-{{- $paginator := .Paginate $pages }}
+{{- $paginator := .Paginate $pages site.Params.pagerSize }}
 
 {{- if and .IsHome site.Params.homeInfoParams (eq $paginator.PageNumber 1) }}
 {{- partial "home_info.html" . }}


### PR DESCRIPTION
**What does this PR change? What problem does it solve?**

This fixes the deprecation of pages that has been made mandatory in Hugo v0.147.6, stopping the theme building.

An extra param 'pagerSize' needs additionally be added to the hugo.yaml params section and set to a reasonable default, such as 5.

**Was the change discussed in an issue or in the Discussions before?**

No

## PR Checklist

- [ N/A] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [X] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [X] I have verified that the code works as described/as intended.
- [N/A] This change adds a Social Icon which has a permissive license to use it.
- [X] This change **does not** include any CDN resources/links.
- [X] This change **does not** include any unrelated scripts such as bash and python scripts.
- [X] This change updates the overridden internal templates from HUGO's repository.
