### PR TITLE
fix: remove double negation

### DIFF
--- a/layouts/partials/index_profile.html
+++ b/layouts/partials/index_profile.html
@@ -13,7 +13,7 @@
             {{- end -}}
             {{- $prod := (hugo.IsProduction | or (eq site.Params.env "production")) }}
             {{- if and (in $processableFormats $img.MediaType.SubType) (eq $prod true)}}
-                {{- if (not (and (not .imageHeight) (not .imageWidth))) }}
+                {{- if (and .imageHeight .imageWidth) }}
                     {{- $img = $img.Resize (printf "%dx%d" .imageWidth .imageHeight) }}
                 {{- else if .imageHeight }}
                     {{- $img = $img.Resize (printf "x%d" .imageHeight) }}


### PR DESCRIPTION
<!--

## READ BEFORE OPENING A PR

Thank you for contributing to hugo-PaperMod!
Please fill out the following questions to make it easier for us to review your
changes. You do not need to check all the boxes below.

**NOTE**: PaperMod does not have any external dependencies fetched from 3rd party
CDN servers. However we do have custom Head/Footer extender templates which you can use
to add those to your website.
https://github.com/adityatelange/hugo-PaperMod/wiki/FAQs#custom-head--footer

-->


**What does this PR change? What problem does it solve?**

Double negation in the index-profile partial was resulting in "if at least one of .imageHeight or .imageWidth is provided, then ...". Now it's "if both .imageWidth and .imageHeight are provided, then ...".




**Was the change discussed in an issue or in the Discussions before?**

Not that I know of.

## PR Checklist

- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [X] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [X] I have verified that the code works as described/as intended.
- [ ] This change adds a Social Icon which has a permissive license to use it.
- [X] This change **does not** include any CDN resources/links.
- [X] This change **does not** include any unrelated scripts such as bash and python scripts.
- [ ] This change updates the overridden internal templates from HUGO's repository.
