### PR TITLE
Figure shortcode

### DIFF
--- a/layouts/shortcodes/figure.html
+++ b/layouts/shortcodes/figure.html
@@ -1,3 +1,24 @@
+{{/*
+    Usage:
+    {{< figure 
+        class="specificclass"
+        align="center"              // this adds "center" to the class of the image
+        src="sourceImage"           //  Image location. May be in the page bundle, in the site resources, or be external to the site (eg: https://other.site/image.png)
+        link="targetOfTheImageLink" //  Makes the image into a link
+        linkFullImage="false        //  If link is NOT provided, AND this parameter is "true",
+                                    //  then makes the image into a link to the full size image
+        responsive="false"          //  If the image is found in the page bundle or in the site resources
+                                    //  AND if the environment is "production"
+                                    //  AND if the image is in a processable format
+                                    //  AND if this parameter is "true", then smaller images are created,
+                                    //              responsiveness is provided by way of srcset, the browser chooses the image size
+        title="Title of the image"
+        alt="Alternative text"
+        caption="Text to appear below the image"
+        attr="End text of the caption"
+        attrlink="targetURLForAttr" // If provided, turns the end text of the caption into a link
+    >}}
+*/}}
 <figure{{ if or (.Get "class") (eq (.Get "align") "center") }} class="
            {{- if eq (.Get "align") "center" }}align-center {{ end }}
            {{- with .Get "class" }}{{ . }}{{- end }}"
@@ -9,31 +30,31 @@
         {{- $processableFormats = $processableFormats | append "webp" -}}
     {{- end -}}
 
+    {{- /* Find the image in the page bundle or in the site resources */ -}}
     {{- $image := "" -}}
-    {{- if $.Page.Resources -}}
-        {{- $image = $.Page.Resources.Get (.Get "src") -}}
+    {{- $imageURL := urls.Parse (.Get "src") -}}
+    {{- $imageSrc := $imageURL.String -}}
+    {{- if not $imageURL.IsAbs -}}
+        {{- $image = or (.Page.Resources.Get $imageURL.Path) (resources.Get $imageURL.Path) -}}
+        {{- $imageSrc = $image.RelPermalink -}}
     {{- end -}}
-    {{- if not $image -}}
-        {{- $image = resources.Get (.Get "src") -}}
-    {{- end -}}
-    {{- $imageSrc := $image.RelPermalink | default ( .Get "src" ) -}}
 
+    {{/* Make the image into a link, provided by the developer, or a link into itself in its original size */}}
     {{- $linkURL := .Get "link" -}}
     {{- $linkFullImage := .Get "linkFullImage" | default "false" | eq "true" -}}
     {{- if and $linkFullImage (not $linkURL) $image -}}
         {{- $linkURL = $image.RelPermalink -}}
     {{- end -}}
 
-    {{- $responsive := .Get "responsive" | default "false" | eq "true" -}}
-
-    {{- $responsive = and $prod $image $responsive ( in $processableFormats $image.MediaType.SubType )  -}}
-
     {{- if $linkURL -}}
         <a href="{{ $linkURL }}"{{ with .Get "target" }} target="{{ . }}"{{ end }}{{ with .Get "rel" }} rel="{{ . }}"{{ end }}>
     {{- end }}
 
+    {{- $responsive := .Get "responsive" | default "false" | eq "true" -}}
+    {{- $responsive = and $prod $image $responsive ( in $processableFormats $image.MediaType.SubType )  -}}
+
     {{- if $responsive }}
-    {{- $sizes := (slice "360" "480" "720" "1080" "1500") }}
+        {{- $sizes := (slice "360" "480" "720" "1080" "1500") }}
     <img loading="lazy" 
         srcset='{{- range $size := $sizes -}}
                     {{- if (ge $image.Width (int $size)) }}


### PR DESCRIPTION
<!--

## READ BEFORE OPENING A PR

Thank you for contributing to hugo-PaperMod!
Please fill out the following questions to make it easier for us to review your
changes. You do not need to check all the boxes below.

**NOTE**: PaperMod does not have any external dependencies fetched from 3rd party
CDN servers. However we do have custom Head/Footer extender templates which you can use
to add those to your website.
https://github.com/adityatelange/hugo-PaperMod/wiki/FAQs#custom-head--footer

-->


**What does this PR change? What problem does it solve?**

This change does two things:
- adds functionalities of responsiveness, and of linkage to full size image, to the figure shortcode, same functionalities as for the cover image. The responsive is false by default, keeping current behaviour. Same for linkFullImage
- adds usage of hugo resources to the former code, using relative links, instead of using the src from the developer. If the image is not found in the resources, takes the src.


**Was the change discussed in an issue or in the Discussions before?**

May well close the issue #1624 . The PR #1651 exists just for this, I saw it after starting my change.


## PR Checklist

- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [X] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [X] I have verified that the code works as described/as intended.
- [ ] This change adds a Social Icon which has a permissive license to use it.
- [X] This change **does not** include any CDN resources/links.
- [X] This change **does not** include any unrelated scripts such as bash and python scripts.
- [ ] This change updates the overridden internal templates from HUGO's repository.
