### PR TITLE
feat(shortcodes): add lazy-loading YouTube embed

### DIFF
--- a/layouts/shortcodes/youtube_lazy.html
+++ b/layouts/shortcodes/youtube_lazy.html
@@ -1,0 +1,14 @@
+{{ $id := .Get 0 }}
+{{ $title := .Get 1 | default "YouTube video" }}
+
+<div style="position:relative;padding-bottom:56.25%;height:0;overflow:hidden;">
+  <iframe
+    title="{{ $title }}"
+    src="https://www.youtube-nocookie.com/embed/{{ $id }}?rel=0"
+    loading="lazy"
+    frameborder="0"
+    allowfullscreen    
+    allow="autoplay; encrypted-media; picture-in-picture"
+    style="position:absolute;top:0;left:0;width:100%;height:100%;">
+  </iframe>
+</div>


### PR DESCRIPTION
<!--

## READ BEFORE OPENING A PR

Thank you for contributing to hugo-PaperMod!
Please fill out the following questions to make it easier for us to review your
changes. You do not need to check all the boxes below.

**NOTE**: PaperMod does not have any external dependencies fetched from 3rd party
CDN servers. However we do have custom Head/Footer extender templates which you can use
to add those to your website.
https://github.com/adityatelange/hugo-PaperMod/wiki/FAQs#custom-head--footer

-->


**What does this PR change? What problem does it solve?**

Adds a new shortcode for embedding YouTube videos with:

- loading="lazy" for performance
- youtube-nocookie.com for privacy
- customizable title for accessibility

Example on how to use it:
`{{< youtube_lazy VID_ID "TITLE">}}`

This improves page speed and ensures more privacy-friendly video embeds.

<!--
Describe the changes and their purpose here, as detailed as and if needed.

Please do not add 2 unrelated changes in a single PR as it is difficult to track/revert those in future.
-->


**Was the change discussed in an issue or in the Discussions before?**

No

<!--
Link issues and relevant Discussions posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->


## PR Checklist

- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have verified that the code works as described/as intended.
- [ ] This change adds a Social Icon which has a permissive license to use it.
- [ ] This change **does not** include any CDN resources/links.
- [ ] This change **does not** include any unrelated scripts such as bash and python scripts.
- [ ] This change updates the overridden internal templates from HUGO's repository.
