### PR TITLE
fix: PaperModテーマのpartial呼び出しパスを修正

### DIFF
--- a/layouts/partials/templates/schema_json.html
+++ b/layouts/partials/templates/schema_json.html
@@ -85,7 +85,7 @@
     {{ (path.Join .RelPermalink .Params.cover.image ) | absURL }},
     {{- end}}
   {{- else }}
-    {{- $images := partial "partials/templates/_funcs/get-page-images" . -}}
+    {{- $images := partial "templates/_funcs/get-page-images" . -}}
     {{- with index $images 0 -}}
   "image": {{ .Permalink }},
     {{- end }}

--- a/layouts/partials/templates/twitter_cards.html
+++ b/layouts/partials/templates/twitter_cards.html
@@ -6,7 +6,7 @@
 <meta name="twitter:image" content="{{ (path.Join .RelPermalink .Params.cover.image ) | absURL }}">
 {{- end}}
 {{- else }}
-{{- $images := partial "partials/templates/_funcs/get-page-images" . -}}
+{{- $images := partial "templates/_funcs/get-page-images" . -}}
 {{- with index $images 0 -}}
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:image" content="{{ .Permalink }}">


### PR DESCRIPTION
Hugoビルドエラーの原因となっていた二重の "partials/" プレフィックスを削除:
- twitter_cards.html: partial "partials/templates/_funcs/get-page-images" → partial "templates/_funcs/get-page-images"
- schema_json.html: 同様の修正

これによりNetlifyでのビルドエラーが解決されます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--

## READ BEFORE OPENING A PR

Thank you for contributing to hugo-PaperMod!
Please fill out the following questions to make it easier for us to review your
changes. You do not need to check all the boxes below.

**NOTE**: PaperMod does not have any external dependencies fetched from 3rd party
CDN servers. However we do have custom Head/Footer extender templates which you can use
to add those to your website.
https://github.com/adityatelange/hugo-PaperMod/wiki/FAQs#custom-head--footer

-->


**What does this PR change? What problem does it solve?**

<!--
Describe the changes and their purpose here, as detailed as and if needed.

Please do not add 2 unrelated changes in a single PR as it is difficult to track/revert those in future.
-->


**Was the change discussed in an issue or in the Discussions before?**

<!--
Link issues and relevant Discussions posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->


## PR Checklist

- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [ ] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have verified that the code works as described/as intended.
- [ ] This change adds a Social Icon which has a permissive license to use it.
- [ ] This change **does not** include any CDN resources/links.
- [ ] This change **does not** include any unrelated scripts such as bash and python scripts.
- [ ] This change updates the overridden internal templates from HUGO's repository.
