### PR TITLE
Fix search index cache issue by adding timestamp to index.json request

### DIFF
--- a/assets/js/fastsearch.js
+++ b/assets/js/fastsearch.js
@@ -48,7 +48,7 @@ window.onload = function () {
             }
         }
     };
-    xhr.open('GET', "../index.json");
+    xhr.open('GET', `../index.json?v=${Date.now()}`);
     xhr.send();
 }
 


### PR DESCRIPTION
<!--

## READ BEFORE OPENING A PR

Thank you for contributing to hugo-PaperMod!
Please fill out the following questions to make it easier for us to review your
changes. You do not need to check all the boxes below.

**NOTE**: PaperMod does not have any external dependencies fetched from 3rd party
CDN servers. However we do have custom Head/Footer extender templates which you can use
to add those to your website.
https://github.com/adityatelange/hugo-PaperMod/wiki/FAQs#custom-head--footer

-->


**What does this PR change? What problem does it solve?**

Adds timestamp query parameter to index.json fetch request in fastsearch.js to force fresh index retrieval.

When fastsearch.js is cached by the browser (common on CDN-hosted sites), it continues fetching index.json without cache-busting parameters. This causes search to return stale results even after deploying new content, because the browser serves both the cached JS file and the cached index.json it references, even if index.json (freshly queried in the browser by the user) contains updated content from the CDN. 

The fix appends `?v=${Date.now()}` to the index.json URL, ensuring each page load fetches current search data regardless of whether fastsearch.js itself is cached.


**Was the change discussed in an issue or in the Discussions before?**

No prior issue filed. Discovered during production deployment where new posts were invisible in search results for non-incognito browsers while index.json contained correct data.


## PR Checklist

- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have verified that the code works as described/as intended.
- [ ] This change adds a Social Icon which has a permissive license to use it.
- [x] This change **does not** include any CDN resources/links.
- [x] This change **does not** include any unrelated scripts such as bash and python scripts.
- [ ] This change updates the overridden internal templates from HUGO's repository.
