### PR TITLE
Allow certain pages to be excluded from RSS feed

### DIFF
--- a/layouts/_default/rss.xml
+++ b/layouts/_default/rss.xml
@@ -38,6 +38,7 @@
 {{- else }}
 {{- $pages = $pctx.Pages }}
 {{- end }}
+{{- $pages = where $pages "Params.rss.exclude" "!=" true -}}
 {{- $limit := site.Config.Services.RSS.Limit }}
 {{- if ge $limit 1 }}
 {{- $pages = $pages | first $limit }}

--- a/layouts/_default/rss.xml
+++ b/layouts/_default/rss.xml
@@ -38,7 +38,7 @@
 {{- else }}
 {{- $pages = $pctx.Pages }}
 {{- end }}
-{{- $pages = where $pages "Params.rss.exclude" "!=" true -}}
+{{- $pages = where $pages "Params.hiddenInRss" "!=" true -}}
 {{- $limit := site.Config.Services.RSS.Limit }}
 {{- if ge $limit 1 }}
 {{- $pages = $pages | first $limit }}


### PR DESCRIPTION
This line adds support for the possibility to exclude a certain page from the RSS feed by adding a param to the front matter:

```
---
rss:
  exclude: true
---
```

**What does this PR change? What problem does it solve?**

This patch allows certain pages to be excluded from the RSS feed.

**Was the change discussed in an issue or in the Discussions before?**

There are a lot of sites around that discuss solutions like this.
It seems to be a common issue.

## PR Checklist

- [-] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [X] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [X] I have verified that the code works as described/as intended.
- [-] This change adds a Social Icon which has a permissive license to use it.
- [X] This change **does not** include any CDN resources/links.
- [X] This change **does not** include any unrelated scripts such as bash and python scripts.
- [-] This change updates the overridden internal templates from HUGO's repository.
