### PR TITLE
Fix incorrect language prefix in menu URLs

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -83,28 +83,41 @@
         {{- $currentPage := . }}
         <ul id="menu">
             {{- range site.Menus.main }}
-            {{- $menu_item_url := (cond (strings.HasSuffix .URL "/") .URL (printf "%s/" .URL) ) | absLangURL }}
-            {{- $page_url:= $currentPage.Permalink | absLangURL }}
-            {{- $is_search := eq (site.GetPage .KeyName).Layout `search` }}
-            <li>
-                <a href="{{ .URL | absLangURL }}" title="{{ .Title | default .Name }} {{- cond $is_search (" (Alt + /)" | safeHTMLAttr) ("" | safeHTMLAttr ) }}"
-                {{- cond $is_search (" accesskey=/" | safeHTMLAttr) ("" | safeHTMLAttr ) }}>
-                    <span {{- if eq $menu_item_url $page_url }} class="active" {{- end }}>
-                        {{- .Pre }}
-                        {{- .Name -}}
-                        {{ .Post -}}
-                    </span>
-                    {{- if (findRE "://" .URL) }}&nbsp;
-                    <svg fill="none" shape-rendering="geometricPrecision" stroke="currentColor" stroke-linecap="round"
-                        stroke-linejoin="round" stroke-width="2.5" viewBox="0 0 24 24" height="12" width="12">
-                        <path d="M18 13v6a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2h6"></path>
-                        <path d="M15 3h6v6"></path>
-                        <path d="M10 14L21 3"></path>
-                    </svg>
-                    {{- end }}
-                </a>
-            </li>
+            {{- $is_external := gt (len (findRE `^(https?:)?//` .URL)) 0 }}
+            {{- $base_path := strings.TrimPrefix "/" ((urls.Parse site.BaseURL).Path) }}
+            {{- $menu_path := strings.TrimPrefix "/" .URL }}
+            {{- $menu_path = strings.TrimPrefix $base_path $menu_path }}
+            {{- $menu_path = cond (strings.HasSuffix $menu_path "/") $menu_path (printf "%s/" $menu_path) }}
+            {{- $href := cond $is_external .URL (printf "%s%s" site.Home.RelPermalink $menu_path) }}
+
+            {{- $menu_item_url := "" }}
+            {{- if not $is_external }}
+            {{- $menu_item_url = $href }}
             {{- end }}
+            {{- $page_url := $currentPage.RelPermalink }}
+
+            {{- $is_search := false }}
+            {{- with site.GetPage .KeyName }}
+            {{- $is_search = eq .Layout "search" }}
+            {{- end }}
+
+            <li>
+            <a href="{{ $href }}" title="{{ .Title | default .Name }}{{ cond $is_search " (Alt + /)" "" }}"
+                {{ if $is_search }} accesskey="/"{{ end }}>
+                <span{{ if and (not $is_external) (eq (strings.TrimSuffix "/" $menu_item_url) (strings.TrimSuffix "/" $page_url)) }} class="active"{{ end }}>
+                {{- .Pre }}{{ .Name }}{{ .Post -}}
+                </span>
+                {{- if $is_external }}&nbsp;
+                <svg fill="none" shape-rendering="geometricPrecision" stroke="currentColor" stroke-linecap="round"
+                    stroke-linejoin="round" stroke-width="2.5" viewBox="0 0 24 24" height="12" width="12">
+                    <path d="M18 13v6a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2h6"></path>
+                    <path d="M15 3h6v6"></path>
+                    <path d="M10 14L21 3"></path>
+                </svg>
+                {{- end }}
+            </a>
+            </li>
+        {{- end }}
         </ul>
     </nav>
 </header>


### PR DESCRIPTION
**What does this PR change? What problem does it solve?**

This PR fixes an issue with incorrect language prefix placement in menu URLs when using a `baseURL` that includes a subpath (e.g., `/blog/`). Previously, when using multilingual configurations (e.g., `zh` and `en`), the `zh` language prefix was incorrectly inserted before the baseURL subpath, resulting in URLs like:
https://leemojiang.github.io/zh/blog/archives/

Instead of the expected:
https://leemojiang.github.io/blog/zh/archives/

What changed
Detect external links (http://, https://, protocol-relative) and skip Hugo internal URL rewriting for them.
For internal links:
Normalize menu paths by removing a leading /.
Remove the baseURL subpath prefix from menu entries when present (to avoid duplicated /blog).
Rebuild links using site.Home.RelPermalink + menu_path so language prefix and subpath order is always correct.
Keep active menu highlighting based on normalized RelPermalink comparison to avoid false mismatches.
This improves compatibility for multilingual deployments under subpaths (for example, GitHub Pages project sites).

You can see an example of the fixed behavior on my blog: [https://leemojiang.github.io/blog/](https://leemojiang.github.io/blog/)

---

**Was the change discussed in an issue or in the Discussions before?**

Yes, this issue is related to [#1661](https://github.com/adityatelange/hugo-PaperMod/issues/1661), where users reported incorrect URL generation when using a `baseURL` with a subpath and multiple languages. A similar issue is also discussed in another theme [#682](https://github.com/CaiJimmy/hugo-theme-stack/issues/682).

---

## PR Checklist

- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have verified that the code works as described/as intended.
- [x] This change does not include any CDN resources/links.
- [x] This change does not include any unrelated scripts such as bash and python scripts.
- [ ] This change updates the overridden internal templates from HUGO's repository.


