### PR TITLE
fix: inherit case for tags from frontmatter

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -46,7 +46,7 @@
     {{- $tags := .Language.Params.Taxonomies.tag | default "tags" }}
     <ul class="post-tags">
       {{- range ($.GetTerms $tags) }}
-      <li><a href="{{ .Permalink }}">{{ .LinkTitle }}</a></li>
+      <li><a href="{{ .Permalink }}">{{ .Name }}</a></li>
       {{- end }}
     </ul>
     {{- if (.Param "ShowPostNavLinks") }}


### PR DESCRIPTION
**What does this PR change? What problem does it solve?**

This PR updates the single post tag rendering to use taxonomy term `.Name` instead of `.LinkTitle` in `layouts/_default/single.html`.

Using `.LinkTitle` causes tags to be title-cased by default in many setups (e.g. `programming` -> `Programming`) even when the source taxonomy term is lowercase. Switching to `.Name` makes tag labels in post footers match taxonomy/terms pages and preserves the original term casing from content/front matter.


**Was the change discussed in an issue or in the Discussions before?**

Not yet.  
I can open an issue/discussion if maintainers prefer review there first.

## PR Checklist

- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have verified that the code works as described/as intended.
- [ ] This change adds a Social Icon which has a permissive license to use it.
- [x] This change **does not** include any CDN resources/links.
- [x] This change **does not** include any unrelated scripts such as bash and python scripts.
- [ ] This change updates the overridden internal templates from HUGO's repository.
