### PR TITLE
Support Markdown in post description

### DIFF
--- a/layouts/_default/archives.html
+++ b/layouts/_default/archives.html
@@ -22,7 +22,11 @@
   </h1>
   {{- if .Description }}
   <div class="post-description">
-    {{ .Description }}
+    {{- if (.Param "markdownifyDescription") }}
+      {{ .Description | markdownify }}
+    {{- else }}
+      {{ .Description }}
+    {{- end }}
   </div>
   {{- end }}
 </header>

--- a/layouts/_default/rss.xml
+++ b/layouts/_default/rss.xml
@@ -60,7 +60,8 @@
       <pubDate>{{ .PublishDate.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
       {{- with $authorEmail }}<author>{{ . }}{{ with $authorName }} ({{ . }}){{ end }}</author>{{ end }}
       <guid>{{ .Permalink }}</guid>
-      <description>{{ with .Description | html }}{{ . }}{{ else }}{{ .Summary | html }}{{ end -}}</description>
+      {{- $markdownify := .Param "markdownifyDescription" }}
+      <description>{{ with .Description }}{{ if $markdownify }}{{ . | markdownify | plainify | html }}{{ else }}{{ . | html }}{{ end }}{{ else }}{{ .Summary | html }}{{ end -}}</description>
       {{- if and site.Params.ShowFullTextinRSS .Content }}
       <content:encoded>{{ (printf "<![CDATA[%s]]>" .Content) | safeHTML }}</content:encoded>
       {{- end }}

--- a/layouts/_default/search.html
+++ b/layouts/_default/search.html
@@ -10,7 +10,11 @@
     </h1>
     {{- if .Description }}
     <div class="post-description">
-        {{ .Description }}
+        {{- if (.Param "markdownifyDescription") }}
+            {{ .Description | markdownify }}
+        {{- else }}
+            {{ .Description }}
+        {{ end }}
     </div>
     {{- end }}
     {{- if not (.Param "hideMeta") }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -16,7 +16,11 @@
     </h1>
     {{- if .Description }}
     <div class="post-description">
-      {{ .Description }}
+      {{- if (.Param "markdownifyDescription") }}
+        {{ .Description | markdownify }}
+      {{- else }}
+        {{ .Description }}
+      {{- end }}
     </div>
     {{- end }}
     {{- if not (.Param "hideMeta") }}

--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -5,7 +5,11 @@
     <h1>{{ .Title }}</h1>
     {{- if .Description }}
     <div class="post-description">
-        {{ .Description }}
+        {{- if (.Param "markdownifyDescription") }}
+            {{ .Description | markdownify }}
+        {{- else }}
+            {{ .Description }}
+        {{- end }}
     </div>
     {{- end }}
 </header>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -18,9 +18,13 @@
     {{- range $i, $e := .Params.keywords }}{{ if $i }}, {{ end }}{{ $e }}{{ end }} {{- else }}
     {{- range $i, $e := .Params.tags }}{{ if $i }}, {{ end }}{{ $e }}{{ end }} {{- end -}}">
 {{- end }}
-<meta name="description" content="{{- with .Description }}{{ . }}{{- else }}{{- if or .IsPage .IsSection}}
-    {{- .Summary | default (printf "%s - %s" .Title  site.Title) }}{{- else }}
-    {{- with site.Params.description }}{{ . }}{{- end }}{{- end }}{{- end -}}">
+{{- $markdownify := .Param "markdownifyDescription" }}
+<meta name="description" content="
+    {{- with .Description }}
+      {{- if $markdownify }}{{- . | markdownify | plainify }}
+      {{- else }}{{- . }}{{- end }}
+    {{- else }}{{- if or .IsPage .IsSection}}{{- .Summary | default (printf "%s - %s" .Title  site.Title) }}
+    {{- else }}{{- with site.Params.description }}{{ . }}{{- end }}{{- end }}{{- end -}}">
 <meta name="author" content="{{ (partial "author.html" . ) }}">
 <link rel="canonical" href="{{ if .Params.canonicalURL -}} {{ trim .Params.canonicalURL " " }} {{- else -}} {{ .Permalink }} {{- end }}">
 {{- if site.Params.analytics.google.SiteVerificationTag }}

--- a/layouts/partials/templates/schema_json.html
+++ b/layouts/partials/templates/schema_json.html
@@ -64,9 +64,10 @@
 {
   "@context": "https://schema.org",
   "@type": "BlogPosting",
-  "headline": {{ .Title | plainify}},
+  "headline": {{ .Title | plainify }},
   "name": "{{ .Title | plainify }}",
-  "description": {{ with .Description | plainify }}{{ . }}{{ else }}{{ .Summary | plainify  }}{{ end -}},
+  {{- $markdownify := .Param "markdownifyDescription" }}
+  "description": {{ with .Description }}{{ if $markdownify }}{{ . | markdownify | plainify }}{{ else }}{{ . | plainify }}{{ end }}{{ else }}{{ .Summary | plainify }}{{ end -}},
   "keywords": [
     {{- if .Params.keywords }}
     {{ range $i, $e := .Params.keywords }}{{ if $i }}, {{ end }}{{ $e }}{{ end }}


### PR DESCRIPTION
**What does this PR change? What problem does it solve?**

I'd like to use the `description` parameter in post frontmatter (particularly to show some content before the cover image). However, that content currently can only be plain text.  I'd like for them to be fed through `| markdownify` so I can at least use inline markup (`**bold**`, `*italics*`, etc).

I didn't want to change existing usage, so I'm introducing a `markdownifyDescription` parameter here that enables this new behavior.

I tried applying this not just to `single.html` but all places where `.Description` is used.

**Was the change discussed in an issue or in the Discussions before?**  Not that I know of.

## PR Checklist

- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have verified that the code works as described/as intended.
- [ ] This change adds a Social Icon which has a permissive license to use it.
- [x] This change **does not** include any CDN resources/links.
- [x] This change **does not** include any unrelated scripts such as bash and python scripts.
- [ ] This change updates the overridden internal templates from HUGO's repository.
